### PR TITLE
Adding missing jinja2 requirement and other fixes

### DIFF
--- a/rasgoql/rasgoql/main.py
+++ b/rasgoql/rasgoql/main.py
@@ -1,7 +1,7 @@
 """
 RasgoQL main class
 """
-from typing import List
+from typing import List, Type
 
 import pandas as pd
 from rasgotransforms import serve_rasgo_transform_templates
@@ -18,7 +18,7 @@ class RasgoQL:
 
     def __init__(
             self,
-            connection: DataWarehouse,
+            connection: Type[DataWarehouse],
             credentials: dict
         ):
         self.credentials = credentials
@@ -62,7 +62,7 @@ class RasgoQL:
                 udt = t
         if udt:
             return udt.define()
-        return ValueError(f'{name} is not a valid Tranform name. ' \
+        raise ValueError(f'{name} is not a valid Tranform name. ' \
                            'Run `.list_transforms()` to see available transforms.')
 
     def query(

--- a/rasgoql/rasgoql/primitives/enums.py
+++ b/rasgoql/rasgoql/primitives/enums.py
@@ -25,7 +25,7 @@ def check_data_warehouse(input_value: str):
     """
     try:
         DWType[input_value.upper()]
-    except:
+    except Exception:
         raise ParameterException(f'data_warehouse parameter accepts values: {SUPPORTED_DWS}')
     return input_value.upper()
 
@@ -46,7 +46,7 @@ def check_table_state(input_value: str):
     """
     try:
         TableState[input_value.upper()]
-    except:
+    except Exception:
         raise ParameterException(f'table_state parameter accepts values: {TABLE_STATES}')
     return input_value.upper()
 
@@ -67,7 +67,7 @@ def check_table_type(input_value: str):
     """
     try:
         TableType[input_value.upper()]
-    except:
+    except Exception:
         raise ParameterException(f'table_type parameter accepts values: {TABLE_TYPES}')
     return input_value.upper()
 
@@ -89,7 +89,7 @@ def check_render_method(input_value: str):
     """
     try:
         RenderMethod[input_value.upper()]
-    except:
+    except Exception:
         raise ParameterException(f'render_method parameter accepts values: {RENDER_METHODS}')
     return input_value.upper()
 
@@ -111,6 +111,6 @@ def check_response_type(input_value: str):
     """
     try:
         ResponseType[input_value.upper()]
-    except:
+    except Exception:
         raise ParameterException(f'response parameter accepts values: {RESPONSE_TYPES}')
     return input_value.upper()

--- a/rasgoql/rasgoql/primitives/rendering.py
+++ b/rasgoql/rasgoql/primitives/rendering.py
@@ -33,6 +33,8 @@ def assemble_cte_chain(
     if table_type:
         table_type = check_table_type(table_type)
 
+    create_stmt, final_select = '', ''
+
     # Handle single transform chains
     if len(transforms) == 1:
         t = transforms[0]
@@ -197,7 +199,7 @@ def _run_query(
     Jinja Func to materialize a chain as a temporary view before running a query
     """
     try:
-        if running_sql > '':
+        if running_sql:
             create_sql = f"CREATE OR REPLACE VIEW {source_table} AS {running_sql} LIMIT {RUN_QUERY_LIMIT}"
             dw.execute_query(create_sql, response='none', acknowledge_risk=True)
         return dw.execute_query(query, response='df', acknowledge_risk=True)

--- a/rasgoql/rasgoql/utils/df.py
+++ b/rasgoql/rasgoql/utils/df.py
@@ -24,7 +24,7 @@ def build_schema(
 
 def cleanse_sql_dataframe(
         df: pd.DataFrame
-    ) -> pd.DataFrame:
+    ):
     """
     Renames all columns in a pandas dataframe to SQL compliant names in place
     """

--- a/rasgoql/requirements.txt
+++ b/rasgoql/requirements.txt
@@ -1,3 +1,4 @@
+jinja2
 pandas
 pyyaml
 python-dotenv


### PR DESCRIPTION
Tried running myself and ran into the issue `ModuleNotFoundError: No module named 'jinja2'` , then went and cleaned up a few obvious things I saw at quick glance. 

The first two are the only two "must fix" to avoid operational issues, the others are less likely to cause issue during normal operation. 

1. Add `jinja2` to `requirements.txt`
2. A ValueError was being returned, not raised
3. There were a few blank `except` clauses which would catch system kills
4. Adding possibly undefined variables `create_stmt` and `final_select` in `rendering` > `assemble_cte_chain`
5. Odd comparison of [None | str] variable `running_sql` against `> ''` in `_run_query`, fixing to simply check truthiness
6. Two type fixes, first is that ABC classes are not considered directly callable, so must check for their subclass with `Type` https://www.python.org/dev/peps/pep-0484/#the-type-of-class-objects and `cleanse_sql_dataframe` states it modifies in places and does not return anything, removing the returned type.