### PR TITLE
Update BigQuery Auth

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for schema.yml dbt file
 ### Changed
 - Changed export to dbt workflow & `SQLChain.to_dbt()` params ([see docs](https://docs.rasgoql.com/workflows/exporting-to-dbt))
-- Simplify BigQuery user connection ([see docs](https://docs.rasgoql.com/datawarehouses/bigquery))
+- Changed auth workflow and `BigQueryCredentials` params ([see docs](https://docs.rasgoql.com/datawarehouses/bigquery))
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/

--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fix
-- BigQuery user auth flow
+- N/A
 
 ### Remove
 - N/A
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for schema.yml dbt file
 ### Changed
 - Changed export to dbt workflow & `SQLChain.to_dbt()` params ([see docs](https://docs.rasgoql.com/workflows/exporting-to-dbt))
+- Simplify BigQuery user connection
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/

--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for schema.yml dbt file
 ### Changed
 - Changed export to dbt workflow & `SQLChain.to_dbt()` params ([see docs](https://docs.rasgoql.com/workflows/exporting-to-dbt))
-- Simplify BigQuery user connection
+- Simplify BigQuery user connection ([see docs](https://docs.rasgoql.com/datawarehouses/bigquery))
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/

--- a/rasgoql/rasgoql/data/bigquery.py
+++ b/rasgoql/rasgoql/data/bigquery.py
@@ -17,7 +17,7 @@ from rasgoql.errors import (
 )
 from rasgoql.imports import bq, gcp_exc, gcp_flow, gcp_svc
 from rasgoql.primitives.enums import (
-    check_bq_creds_type, check_response_type,
+    check_response_type,
     check_table_type, check_write_method
 )
 from rasgoql.utils.creds import load_env, save_env

--- a/rasgoql/rasgoql/data/snowflake.py
+++ b/rasgoql/rasgoql/data/snowflake.py
@@ -548,6 +548,7 @@ class SnowflakeDataWarehouse(DataWarehouse):
                 'that http connections to Snowflake are whitelisted in your env. '
                 'Finally check https://status.snowflake.com/ for outage status.'
             ) from exception
+        raise exception
 
     def _execute_dict_cursor(
             self,

--- a/rasgoql/rasgoql/data/snowflake.py
+++ b/rasgoql/rasgoql/data/snowflake.py
@@ -80,27 +80,26 @@ class SnowflakeCredentials(DWCredentials):
         Creates an instance of this Class from a .env file on your machine
         """
         load_env(filepath)
-        if not all([
-                os.getenv('snowflake_account'),
-                os.getenv('snowflake_user'),
-                os.getenv('snowflake_password'),
-                os.getenv('snowflake_role'),
-                os.getenv('snowflake_warehouse'),
-                os.getenv('snowflake_database'),
-                os.getenv('snowflake_schema')
-        ]):
+        account = os.getenv('snowflake_account'),
+        user = os.getenv('snowflake_user'),
+        password = os.getenv('snowflake_password'),
+        role = os.getenv('snowflake_role'),
+        warehouse = os.getenv('snowflake_warehouse'),
+        database = os.getenv('snowflake_database'),
+        schema = os.getenv('snowflake_schema')
+        if not all([account, user, password, role, warehouse, database, schema]):
             raise DWCredentialsWarning(
                 'Your env file is missing expected credentials. Consider running '
                 'SnowflakeCredentials(*args).to_env() to repair this.'
             )
         return cls(
-            os.getenv('snowflake_account'),
-            os.getenv('snowflake_user'),
-            os.getenv('snowflake_password'),
-            os.getenv('snowflake_role'),
-            os.getenv('snowflake_warehouse'),
-            os.getenv('snowflake_database'),
-            os.getenv('snowflake_schema')
+            account,
+            user,
+            password,
+            role,
+            warehouse,
+            database,
+            schema
         )
 
     def to_dict(self) -> dict:

--- a/rasgoql/rasgoql/primitives/enums.py
+++ b/rasgoql/rasgoql/primitives/enums.py
@@ -9,24 +9,6 @@ from rasgoql.errors import ParameterException
 def _wrap_in_quotes(string: str) -> str:
     return f"'{string}'"
 
-class BQCredsType(Enum):
-    """
-    Ways to write data
-    """
-    USER = 'user'
-    SERVICE = 'service'
-
-def check_bq_creds_type(input_value: str):
-    """
-    Warn if an incorrect write method is passed
-    """
-    bq_creds_types = _wrap_in_quotes("', '".join([e.value for e in BQCredsType]))
-    try:
-        BQCredsType[input_value.upper()]
-    except Exception:
-        raise ParameterException(f'creds_type parameter accepts values: {bq_creds_types}')
-    return input_value.upper()
-
 class DWType(Enum):
     """
     Supported Data Warehouses

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
Change BigQuery connect workflow:
- Respect the `GOOGLE_APPLICATION_CREDENTIALS` env var if users have it set
- remove `secret_type` param from BigQueryCredentials: automatically detect and handle file type
- rename BigQueryCredentials param `secret_filepath` to `json_filepath` for clarity
- remove BQCredsType enum

Bug Fixes:
- Fix error handling bug from last PR