### PR TITLE
Fix: Loosen fqtn logic

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -15,9 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fix
-- Loosen restriction on what constitutes a valid fqtn
-    - FROM: `\w+\.\w+\.\w+` (mandate: word.word.word)
-    - TO: `^[^\s]+\.[^\s]+\.[^\s]+` (mandate: anychars.anychars.anychars)
+- N/A
 
 ### Remove
 - N/A
@@ -36,5 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed export to dbt workflow & `SQLChain.to_dbt()` params ([see docs](https://docs.rasgoql.com/workflows/exporting-to-dbt))
 - Changed auth workflow and `BigQueryCredentials` params ([see docs](https://docs.rasgoql.com/datawarehouses/bigquery))
 
+## [1.0.2] - 2022-03-02
+## Changed
+- Loosened restriction on what constitutes a valid fqtn
+    - FROM: `\w+\.\w+\.\w+` (mandate: word.word.word)
+    - TO: `^[^\s]+\.[^\s]+\.[^\s]+` (mandate: anychars.anychars.anychars)
+### Fixed
+- Fixed bug that loaded account param as a list when calling `SnowflakeCredentials.from_env()`
+
+
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/
+[1.0.2]: https://pypi.org/project/rasgoql/1.0.2/

--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fix
-- N/A
+- Loosen restriction on what constitutes a valid fqtn
+    - FROM: `\w+\.\w+\.\w+` (mandate: word.word.word)
+    - TO: `^[^\s]+\.[^\s]+\.[^\s]+` (mandate: anychars.anychars.anychars)
 
 ### Remove
 - N/A

--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -34,11 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed export to dbt workflow & `SQLChain.to_dbt()` params ([see docs](https://docs.rasgoql.com/workflows/exporting-to-dbt))
 - Changed auth workflow and `BigQueryCredentials` params ([see docs](https://docs.rasgoql.com/datawarehouses/bigquery))
 
-## [1.0.2] - 2022-03-02
+## [1.0.2] - 2022-03-03
+## Added
+- Added `acknowledge_risk` parameter to `.query()` and `.query_into_df()` functions
+- Added support for loading external and temporary tables as Datasets
+
 ## Changed
 - Loosened restriction on what constitutes a valid fqtn
     - FROM: `\w+\.\w+\.\w+` (mandate: word.word.word)
     - TO: `^[^\s]+\.[^\s]+\.[^\s]+` (mandate: anychars.anychars.anychars)
+
 ### Fixed
 - Fixed bug that loaded account param as a list when calling `SnowflakeCredentials.from_env()`
 

--- a/rasgoql/rasgoql/data/bigquery.py
+++ b/rasgoql/rasgoql/data/bigquery.py
@@ -18,7 +18,7 @@ from rasgoql.errors import (
 from rasgoql.imports import bq, gcp_exc, gcp_flow, gcp_svc
 from rasgoql.primitives.enums import (
     check_response_type,
-    check_table_type, check_write_method
+    check_write_method, check_write_table_type
 )
 from rasgoql.utils.creds import load_env, save_env
 from rasgoql.utils.df import cleanse_sql_dataframe
@@ -227,7 +227,7 @@ class BigQueryDataWarehouse(DataWarehouse):
             and you know you want to overwrite it
             WARNING: This will completely overwrite data in the existing table
         """
-        table_type = check_table_type(table_type)
+        table_type = check_write_table_type(table_type)
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         if self._table_exists(fqtn) and not overwrite:
             msg = f'A table or view named {fqtn} already exists. ' \

--- a/rasgoql/rasgoql/data/snowflake.py
+++ b/rasgoql/rasgoql/data/snowflake.py
@@ -82,12 +82,12 @@ class SnowflakeCredentials(DWCredentials):
         Creates an instance of this Class from a .env file on your machine
         """
         load_env(filepath)
-        account = os.getenv('SNOWFLAKE_ACCOUNT'),
-        user = os.getenv('SNOWFLAKE_USER'),
-        password = os.getenv('SNOWFLAKE_PASSWORD'),
-        role = os.getenv('SNOWFLAKE_ROLE'),
-        warehouse = os.getenv('SNOWFLAKE_WAREHOUSE'),
-        database = os.getenv('SNOWFLAKE_DATABASE'),
+        account = os.getenv('SNOWFLAKE_ACCOUNT')
+        user = os.getenv('SNOWFLAKE_USER')
+        password = os.getenv('SNOWFLAKE_PASSWORD')
+        role = os.getenv('SNOWFLAKE_ROLE')
+        warehouse = os.getenv('SNOWFLAKE_WAREHOUSE')
+        database = os.getenv('SNOWFLAKE_DATABASE')
         schema = os.getenv('SNOWFLAKE_SCHEMA')
         if not all([account, user, password, role, warehouse, database, schema]):
             raise DWCredentialsWarning(

--- a/rasgoql/rasgoql/data/snowflake.py
+++ b/rasgoql/rasgoql/data/snowflake.py
@@ -16,7 +16,7 @@ from rasgoql.errors import (
 )
 from rasgoql.imports import sf_connector, write_pandas
 from rasgoql.primitives.enums import (
-    check_response_type, check_table_type, check_write_method
+    check_response_type, check_write_method, check_write_table_type
 )
 from rasgoql.utils.creds import load_env, save_env
 from rasgoql.utils.df import cleanse_sql_dataframe, generate_dataframe_ddl
@@ -252,7 +252,7 @@ class SnowflakeDataWarehouse(DataWarehouse):
             and you know you want to overwrite it
             WARNING: This will completely overwrite data in the existing table
         """
-        table_type = check_table_type(table_type)
+        table_type = check_write_table_type(table_type)
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         if self._table_exists(fqtn) and not overwrite:
             msg = f'A table or view named {fqtn} already exists. ' \

--- a/rasgoql/rasgoql/main.py
+++ b/rasgoql/rasgoql/main.py
@@ -100,21 +100,23 @@ class RasgoQL:
 
     def query(
             self,
-            sql: str
+            sql: str,
+            acknowledge_risk: bool = False
         ):
         """
         Execute a query against your Data Warehouse
         """
-        return self._dw.execute_query(sql)
+        return self._dw.execute_query(sql, acknowledge_risk=acknowledge_risk)
 
     def query_into_df(
             self,
-            sql: str
+            sql: str,
+            acknowledge_risk: bool = False
         ) -> pd.DataFrame:
         """
         Execute a query against your Data Warehouse and return results in a pandas DataFrame
         """
-        return self._dw.execute_query(sql, response='df')
+        return self._dw.execute_query(sql, response='df', acknowledge_risk=acknowledge_risk)
 
     def set_verbose(
             self,

--- a/rasgoql/rasgoql/primitives/enums.py
+++ b/rasgoql/rasgoql/primitives/enums.py
@@ -2,8 +2,13 @@
 Enums
 """
 from enum import Enum
+import logging
 
 from rasgoql.errors import ParameterException
+
+logging.basicConfig()
+logger = logging.getLogger('Enums')
+logger.setLevel(logging.INFO)
 
 
 def _wrap_in_quotes(string: str) -> str:
@@ -13,9 +18,9 @@ class DWType(Enum):
     """
     Supported Data Warehouses
     """
-    BIGQUERY = 'bigquery'
-    #FUTURE: POSTGRES = 'postgres'
-    SNOWFLAKE = 'snowflake'
+    BIGQUERY = 'BIGQUERY'
+    #FUTURE: POSTGRES = 'POSTGRES'
+    SNOWFLAKE = 'SNOWFLAKE'
 
 def check_data_warehouse(input_value: str):
     """
@@ -23,19 +28,19 @@ def check_data_warehouse(input_value: str):
     """
     supported_dws = _wrap_in_quotes("', '".join([e.value for e in DWType]))
     try:
-        DWType[input_value.upper()]
+        output_value = DWType[input_value.upper()].value
     except Exception:
         raise ParameterException(f'data_warehouse parameter accepts values: {supported_dws}')
-    return input_value.upper()
+    return output_value
 
 
 class TableState(Enum):
     """
     State of a table
     """
-    IN_DW = 'in dw'
-    IN_MEMORY = 'in memory'
-    UNKNOWN = 'unknown'
+    IN_DW = 'IN DW'
+    IN_MEMORY = 'IN MEMORY'
+    UNKNOWN = 'UNKNOWN'
 
 def check_table_state(input_value: str):
     """
@@ -43,19 +48,21 @@ def check_table_state(input_value: str):
     """
     table_states = _wrap_in_quotes("', '".join([e.value for e in TableState]))
     try:
-        TableState[input_value.upper()]
+        output_value = TableState[input_value.upper()].value
     except Exception:
         raise ParameterException(f'table_state parameter accepts values: {table_states}')
-    return input_value.upper()
+    return output_value
 
 
 class TableType(Enum):
     """
     Type of table in a DW
     """
-    TABLE = 'table'
-    VIEW = 'view'
-    UNKNOWN = 'unknown'
+    EXTERNAL = 'EXTERNAL'
+    TABLE = 'TABLE'
+    TEMPORARY = 'TEMPORARY'
+    UNKNOWN = 'UNKNOWN'
+    VIEW = 'VIEW'
 
 def check_table_type(input_value: str):
     """
@@ -63,20 +70,24 @@ def check_table_type(input_value: str):
     """
     table_types = _wrap_in_quotes("', '".join([e.value for e in TableType]))
     try:
-        TableType[input_value.upper()]
+        output_value = TableType[input_value.upper()].value
     except Exception:
-        raise ParameterException(f'table_type parameter accepts values: {table_types}')
-    return input_value.upper()
+        logger.warning(
+            f'{input_value} is an unexpected value for table_type. '
+            f'Expected values are: {table_types}. '
+            'Defaulting to UNKNOWN type.')
+        return TableType.UNKNOWN.value
+    return output_value
 
 
 class RenderMethod(Enum):
     """
     Ways to render a sql chain
     """
-    SELECT = 'select'
-    TABLE = 'table'
-    VIEW = 'view'
-    VIEWS = 'views'
+    SELECT = 'SELECT'
+    TABLE = 'TABLE'
+    VIEW = 'VIEW'
+    VIEWS = 'VIEWS'
 
 def check_render_method(input_value: str):
     """
@@ -84,20 +95,20 @@ def check_render_method(input_value: str):
     """
     render_methods = _wrap_in_quotes("', '".join([e.value for e in RenderMethod]))
     try:
-        RenderMethod[input_value.upper()]
+        output_value = RenderMethod[input_value.upper()].value
     except Exception:
         raise ParameterException(f'render_method parameter accepts values: {render_methods}')
-    return input_value.upper()
+    return output_value
 
 
 class ResponseType(Enum):
     """
     Formats to return query results
     """
-    DICT = 'dict'
-    DF = 'df'
-    TUPLE = 'tuple'
-    NONE = 'none'
+    DICT = 'DICT'
+    DF = 'DF'
+    TUPLE = 'TUPLE'
+    NONE = 'NONE'
 
 def check_response_type(input_value: str):
     """
@@ -105,19 +116,19 @@ def check_response_type(input_value: str):
     """
     response_types = _wrap_in_quotes("', '".join([e.value for e in ResponseType]))
     try:
-        ResponseType[input_value.upper()]
+        output_value = ResponseType[input_value.upper()].value
     except Exception:
         raise ParameterException(f'response parameter accepts values: {response_types}')
-    return input_value.upper()
+    return output_value
 
 
 class WriteMethod(Enum):
     """
     Ways to write data
     """
-    APPEND = 'append'
-    REPLACE = 'replace'
-    UPSERT = 'upsert'
+    APPEND = 'APPEND'
+    REPLACE = 'REPLACE'
+    UPSERT = 'UPSERT'
 
 def check_write_method(input_value: str):
     """
@@ -125,7 +136,26 @@ def check_write_method(input_value: str):
     """
     write_methods = _wrap_in_quotes("', '".join([e.value for e in WriteMethod]))
     try:
-        WriteMethod[input_value.upper()]
+        output_value = WriteMethod[input_value.upper()].value
     except Exception:
         raise ParameterException(f'method parameter accepts values: {write_methods}')
-    return input_value.upper()
+    return output_value
+
+
+class WriteTableType(Enum):
+    """
+    Type of table in a DW
+    """
+    TABLE = 'TABLE'
+    VIEW = 'VIEW'
+
+def check_write_table_type(input_value: str):
+    """
+    Warn if an incorrect table type is passed
+    """
+    table_types = _wrap_in_quotes("', '".join([e.value for e in WriteTableType]))
+    try:
+        output_value = WriteTableType[input_value.upper()].value
+    except Exception:
+        raise ParameterException(f'table_type parameter accepts values: {table_types}')
+    return output_value

--- a/rasgoql/rasgoql/primitives/rendering.py
+++ b/rasgoql/rasgoql/primitives/rendering.py
@@ -13,7 +13,7 @@ import pandas as pd
 import rasgotransforms as rtx
 
 from rasgoql.errors import TransformRenderingError
-from rasgoql.primitives.enums import check_table_type
+from rasgoql.primitives.enums import check_write_table_type
 from rasgoql.utils.dbt import save_model_file
 
 RUN_QUERY_LIMIT = 100
@@ -278,8 +278,7 @@ def _set_create_statement(
     Returns a create statement or a blank string
     """
     if table_type:
-        table_type = check_table_type(table_type)
-    if table_type in ['TABLE', 'VIEW']:
+        table_type = check_write_table_type(table_type)
         return f'CREATE OR REPLACE {table_type} {fqtn} AS \n'
     return ''
 

--- a/rasgoql/rasgoql/utils/decorators.py
+++ b/rasgoql/rasgoql/utils/decorators.py
@@ -5,6 +5,8 @@ import functools
 import logging
 from typing import Callable, Union
 
+from rasgoql.primitives.enums import TableState
+
 logging.basicConfig()
 logger = logging.getLogger('rasgoQL')
 logger.setLevel(logging.INFO)
@@ -59,6 +61,18 @@ def require_dw(func: Callable) -> Callable:
         self: Union['Dataset', 'Transform', 'SQLChain'] = args[0]
         if not self._dw:
             raise NotImplementedError(f'{func.__name__} method is only available for classes instantiated with a DW connection')
+        return func(*args, **kwargs)
+    return wrapper
+
+def require_materialized(func: Callable) -> Callable:
+    """
+    Decorator to restrict Class methods
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        self: 'Dataset' = args[0]
+        if self.table_state != TableState.IN_DW.value:
+            raise NotImplementedError(f'{func.__name__} method is only available for tables that exist in the DataWarehouse')
         return func(*args, **kwargs)
     return wrapper
 

--- a/rasgoql/rasgoql/utils/sql.py
+++ b/rasgoql/rasgoql/utils/sql.py
@@ -118,7 +118,7 @@ def validate_fqtn(
     """
     Accepts a possible fully qualified table string and decides whether it is well formed
     """
-    if re.match(r'\w+\.\w+\.\w+', fqtn):
+    if re.match(r'^[^\s]+\.[^\s]+\.[^\s]+', fqtn):
         return fqtn
     raise ValueError(f'{fqtn} is not a well-formed fqtn')
 
@@ -128,7 +128,7 @@ def validate_namespace(
     """
     Accepts a possible namespace string and decides whether it is well formed
     """
-    if re.match(r'\w+\.\w+', namespace):
+    if re.match(r'^[^\s]+\.[^\s]+', namespace):
         return namespace
     raise ValueError(f'{namespace} is not a well-formed namespace')
 

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.0.2a1'
+__version__ = '1.0.2'

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.0.1'
+__version__ = '1.0.2a1'


### PR DESCRIPTION
Changes:
- adds acknowledge_risk parameter to `query()` and `query_into_df()` functions
- adds support for external and temporary tables
- patches a bug in `SnowflakeCredentials.from_env()` introduced in 1.0.1 😬 
- Loosens the definition of a "valid" fqtn
FROM: `<word>.<word>.<word>`
TO:` <1 or more non-whitespace chars>.<1 or more non-whitespace chars>.<1 or more non-whitespace chars>`

Covers user request from issue: https://github.com/rasgointelligence/RasgoQL/issues/49

