### PR TITLE
Fix transforms function signature

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add SQLChain to/from YAML workflow
 
 ### Change
-- N/A
+- make `name` a mandatory parameter in SQLChain and Dataset `.transform()` methods
 
 ### Fix
 - N/A

--- a/rasgoql/rasgoql/primitives/transforms.py
+++ b/rasgoql/rasgoql/primitives/transforms.py
@@ -69,7 +69,7 @@ class TransformableClass:
     @require_dw
     def transform(
             self,
-            name: str = None,
+            name: str,
             arguments: dict = None,
             output_alias: str = None,
             **kwargs


### PR DESCRIPTION
Letting `name` default to None is confusing to users and leaves the door open for downstream bugs vs. parameter warnings. This PR makes it mandatory.