### PR TITLE
Enhancement/mysql support

### DIFF
--- a/rasgoql/rasgoql/__init__.py
+++ b/rasgoql/rasgoql/__init__.py
@@ -1,30 +1,33 @@
 """
 RasgoQL package entrypoint
 """
-from typing import Union
-
 import webbrowser
 
 from rasgoql.data import (
     DWCredentials,
-    BigQueryCredentials, BigQueryDataWarehouse,
-    SnowflakeCredentials, SnowflakeDataWarehouse,
-    PostgresCredentials, PostgresDataWarehouse
+    BigQueryCredentials,
+    BigQueryDataWarehouse,
+    SnowflakeCredentials,
+    SnowflakeDataWarehouse,
+    PostgresCredentials,
+    PostgresDataWarehouse,
+    MySQLCredentials,
+    MySQLDataWarehouse,
 )
-from rasgoql.errors import ParameterException
 from rasgoql.main import RasgoQL
 from rasgoql.version import __version__
 
 __all__ = [
-    '__version__',
-    'docs',
-    'connect',
+    "__version__",
+    "docs",
+    "connect",
 ]
 
 DW_MAP = {
-    'snowflake': SnowflakeDataWarehouse,
-    'bigquery': BigQueryDataWarehouse,
-    'postgresql': PostgresDataWarehouse,
+    "snowflake": SnowflakeDataWarehouse,
+    "bigquery": BigQueryDataWarehouse,
+    "postgresql": PostgresDataWarehouse,
+    "mysql": MySQLDataWarehouse,
 }
 
 
@@ -32,17 +35,15 @@ def docs():
     """
     Open Rasgo Docs page
     """
-    url = 'https://docs.rasgoql.com'
+    url = "https://docs.rasgoql.com"
     webbrowser.open(url)
     print(url)
 
-def connect(
-        credentials: DWCredentials
-    ):
+
+def connect(credentials: DWCredentials):
     """
     Return a RasgoQL object connected to a Data Warehouse
     """
     return RasgoQL(
-        connection=DW_MAP[credentials.dw_type],
-        credentials=credentials.to_dict()
+        connection=DW_MAP[credentials.dw_type], credentials=credentials.to_dict()
     )

--- a/rasgoql/rasgoql/data/__init__.py
+++ b/rasgoql/rasgoql/data/__init__.py
@@ -2,3 +2,4 @@ from rasgoql.data.base import DataWarehouse, DWCredentials
 from rasgoql.data.bigquery import BigQueryDataWarehouse, BigQueryCredentials
 from rasgoql.data.snowflake import SnowflakeDataWarehouse, SnowflakeCredentials
 from rasgoql.data.postgres import PostgresCredentials, PostgresDataWarehouse
+from rasgoql.data.mysql import MySQLCredentials, MySQLDataWarehouse

--- a/rasgoql/rasgoql/data/mysql.py
+++ b/rasgoql/rasgoql/data/mysql.py
@@ -1,5 +1,5 @@
 """
-Postgres DataWarehouse classes
+MySQL DataWarehouse classes
 """
 import logging
 import os
@@ -38,7 +38,6 @@ class PostgresCredentials(DWCredentials):
     """
     dw_type = 'postgresql'
 
-    # TODO: override anything with port to ensure we pick up port in creds
     def __init__(
             self,
             username: str,
@@ -52,7 +51,7 @@ class PostgresCredentials(DWCredentials):
             raise PackageDependencyWarning(
                 'Missing a required python package to run Postgres. '
                 'Please download the Postgres package by running: '
-                'pip install rasgoql[postgres]')
+                'pip install rasgoql[snowflake]')
         self.username = username
         self.password = password
         self.host = host

--- a/rasgoql/rasgoql/data/mysql.py
+++ b/rasgoql/rasgoql/data/mysql.py
@@ -12,18 +12,18 @@ from rasgoql.data.base import DWCredentials
 from rasgoql.data.sqlalchemy import SQLAlchemyDataWarehouse
 
 from rasgoql.errors import (
-    DWCredentialsWarning, PackageDependencyWarning, TableConflictException
+    DWCredentialsWarning,
+    PackageDependencyWarning,
+    TableConflictException,
 )
 from rasgoql.imports import alchemy_engine, alchemy_session
 from rasgoql.primitives.enums import check_table_type
 from rasgoql.utils.creds import load_env, save_env
 from rasgoql.utils.messaging import verbose_message
-from rasgoql.utils.sql import (
-    magic_fqtn_handler, parse_fqtn, parse_table_and_schema_from_fqtn
-)
+from rasgoql.utils.sql import magic_fqtn_handler, parse_fqtn
 
 logging.basicConfig()
-logger = logging.getLogger('MySQL DataWarehouse')
+logger = logging.getLogger("MySQL DataWarehouse")
 logger.setLevel(logging.INFO)
 
 
@@ -31,22 +31,19 @@ class MySQLCredentials(DWCredentials):
     """
     MySQL Credentials
     """
-    dw_type = 'mysql'
-    db_api = 'pymysql'
+
+    dw_type = "mysql"
+    db_api = "pymysql"
 
     def __init__(
-            self,
-            username: str,
-            password: str,
-            host: str,
-            database: str,
-            schema: str
-        ):
+        self, username: str, password: str, host: str, database: str, schema: str
+    ):
         if alchemy_engine is None:
             raise PackageDependencyWarning(
-                'Missing a required python package to run MySQL. '
-                'Please download the MySQL package by running: '
-                'pip install rasgoql[mysql]')
+                "Missing a required python package to run MySQL. "
+                "Please download the MySQL package by running: "
+                "pip install rasgoql[mysql]"
+            )
         self.username = username
         self.password = password
         self.host = host
@@ -64,31 +61,22 @@ class MySQLCredentials(DWCredentials):
         )
 
     @classmethod
-    def from_env(
-            cls,
-            filepath: str = None
-        ) -> 'MySQLCredentials':
+    def from_env(cls, filepath: str = None) -> "MySQLCredentials":
         """
         Creates an instance of this Class from a .env file on your machine
         """
         load_env(filepath)
-        username = os.getenv('MYSQL_USERNAME')
-        password = os.getenv('MYSQL_PASSWORD')
-        host = os.getenv('MYSQL_HOST')
-        database = os.getenv('MYSQL_DATABASE')
-        schema = os.getenv('MYSQL_SCHEMA')
+        username = os.getenv("MYSQL_USERNAME")
+        password = os.getenv("MYSQL_PASSWORD")
+        host = os.getenv("MYSQL_HOST")
+        database = os.getenv("MYSQL_DATABASE")
+        schema = os.getenv("MYSQL_SCHEMA")
         if not all([username, password, host, database, schema]):
             raise DWCredentialsWarning(
-                'Your env file is missing expected credentials. Consider running '
-                'MySQLCredentials(*args).to_env() to repair this.'
+                "Your env file is missing expected credentials. Consider running "
+                "MySQLCredentials(*args).to_env() to repair this."
             )
-        return cls(
-            username,
-            password,
-            host,
-            database,
-            schema
-        )
+        return cls(username, password, host, database, schema)
 
     def to_dict(self) -> dict:
         """
@@ -100,14 +88,10 @@ class MySQLCredentials(DWCredentials):
             "host": self.host,
             "database": self.database,
             "schema": self.schema,
-            "dw_type": self.dw_type
+            "dw_type": self.dw_type,
         }
 
-    def to_env(
-            self,
-            filepath: str = None,
-            overwrite: bool = False
-        ):
+    def to_env(self, filepath: str = None, overwrite: bool = False):
         """
         Saves credentials to a .env file on your machine
         """
@@ -116,7 +100,7 @@ class MySQLCredentials(DWCredentials):
             "MYSQL_PASSWORD": self.password,
             "MYSQL_HOST": self.host,
             "MYSQL_DATABASE": self.database,
-            "MYSQL_SCHEMA": self.schema
+            "MYSQL_SCHEMA": self.schema,
         }
         return save_env(creds, filepath, overwrite)
 
@@ -125,7 +109,8 @@ class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
     """
     MySQL DataWarehouse
     """
-    dw_type = 'mysql'
+
+    dw_type = "mysql"
     credentials_class = MySQLCredentials
 
     def __init__(self):
@@ -134,10 +119,7 @@ class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
     # ---------------------------
     # Core Data Warehouse methods
     # ---------------------------
-    def change_namespace(
-            self,
-            namespace: str
-        ) -> None:
+    def change_namespace(self, namespace: str) -> None:
         """
         Changes the default namespace of your connection
 
@@ -150,10 +132,7 @@ class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
             "Please build a new connection using the MySQLCredentials class"
         )
 
-    def connect(
-            self,
-            credentials: Union[dict, MySQLCredentials]
-        ):
+    def connect(self, credentials: Union[dict, MySQLCredentials]):
         """
         Connect to Postgres
 
@@ -166,23 +145,16 @@ class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
 
         try:
             self.credentials = credentials
-            self.database = credentials.get('database')
-            self.schema = credentials.get('schema')
+            self.database = credentials.get("database")
+            self.schema = credentials.get("schema")
             self.connection = alchemy_session(self._engine)
-            verbose_message(
-                "Connected to MySQL",
-                logger
-            )
+            verbose_message("Connected to MySQL", logger)
         except Exception as e:
             self._error_handler(e)
 
     def create(
-            self,
-            sql: str,
-            fqtn: str,
-            table_type: str = 'VIEW',
-            overwrite: bool = False
-        ):
+        self, sql: str, fqtn: str, table_type: str = "VIEW", overwrite: bool = False
+    ):
         """
         Create a view or table from given SQL
 
@@ -202,18 +174,17 @@ class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
         table_type = check_table_type(table_type)
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         if self._table_exists(fqtn=fqtn) and not overwrite:
-            msg = f'A table or view named {fqtn} already exists. ' \
-                   'If you are sure you want to overwrite it, ' \
-                   'pass in overwrite=True and run this function again'
+            msg = (
+                f"A table or view named {fqtn} already exists. "
+                "If you are sure you want to overwrite it, "
+                "pass in overwrite=True and run this function again"
+            )
             raise TableConflictException(msg)
         query = f"CREATE OR REPLACE {table_type} {fqtn} AS {sql}"
-        self.execute_query(query, acknowledge_risk=True, response='None')
+        self.execute_query(query, acknowledge_risk=True, response="None")
         return fqtn
 
-    def get_ddl(
-            self,
-            fqtn: str
-        ) -> pd.DataFrame:
+    def get_ddl(self, fqtn: str) -> pd.DataFrame:
         """
         Returns a DataFrame describing the column in the table
 
@@ -223,13 +194,10 @@ class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         _, schema_name, table_name = parse_fqtn(fqtn)
         sql = f"SHOW CREATE TABLE {schema_name}.{table_name}"
-        query_response = self.execute_query(sql, response='DF')
+        query_response = self.execute_query(sql, response="DF")
         return query_response
 
-    def get_object_details(
-            self,
-            fqtn: str
-        ) -> tuple:
+    def get_object_details(self, fqtn: str) -> tuple:
         """
         Return details of a table or view in MySQL
 
@@ -245,19 +213,17 @@ class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         _, schema, table = parse_fqtn(fqtn)
         sql = f"SHOW TABLES LIKE '{table}' IN {schema}"
-        result = self.execute_query(sql, response='dict')
+        result = self.execute_query(sql, response="dict")
         obj_exists = len(result) > 0
         is_rasgo_obj = False
-        obj_type = 'unknown'
+        obj_type = "unknown"
         return obj_exists, is_rasgo_obj, obj_type
 
     # --------------------------
     # MySQL specific helpers
     # --------------------------
     @property
-    def _engine(
-            self
-        ) -> 'alchemy_engine':
+    def _engine(self) -> "alchemy_engine":
         """
         Returns a SQLAlchemy engine
         """

--- a/rasgoql/rasgoql/data/mysql.py
+++ b/rasgoql/rasgoql/data/mysql.py
@@ -3,59 +3,53 @@ MySQL DataWarehouse classes
 """
 import logging
 import os
-from typing import List, Union
+from typing import Union
 
 import json
 import pandas as pd
 
-from rasgoql.data.base import DataWarehouse, DWCredentials
+from rasgoql.data.base import DWCredentials
+from rasgoql.data.sqlalchemy import SQLAlchemyDataWarehouse
+
 from rasgoql.errors import (
-    DWCredentialsWarning, DWConnectionError, DWQueryError,
-    PackageDependencyWarning, ParameterException,
-    SQLWarning, TableAccessError, TableConflictException
+    DWCredentialsWarning, PackageDependencyWarning, TableConflictException
 )
-from rasgoql.imports import alchemy_engine, alchemy_session, alchemy_exceptions
-from rasgoql.primitives.enums import (
-    check_response_type, check_table_type, check_write_method
-)
+from rasgoql.imports import alchemy_engine, alchemy_session
+from rasgoql.primitives.enums import check_table_type
 from rasgoql.utils.creds import load_env, save_env
-from rasgoql.utils.df import cleanse_sql_dataframe, generate_dataframe_ddl
 from rasgoql.utils.messaging import verbose_message
 from rasgoql.utils.sql import (
-    is_scary_sql, magic_fqtn_handler,
-    parse_fqtn, parse_table_and_schema_from_fqtn,
-    validate_namespace
+    magic_fqtn_handler, parse_fqtn, parse_table_and_schema_from_fqtn
 )
 
 logging.basicConfig()
-logger = logging.getLogger('Postgres DataWarehouse')
+logger = logging.getLogger('MySQL DataWarehouse')
 logger.setLevel(logging.INFO)
 
 
-class PostgresCredentials(DWCredentials):
+class MySQLCredentials(DWCredentials):
     """
-    Postgres Credentials
+    MySQL Credentials
     """
-    dw_type = 'postgresql'
+    dw_type = 'mysql'
+    db_api = 'pymysql'
 
     def __init__(
             self,
             username: str,
             password: str,
             host: str,
-            port: str,
             database: str,
             schema: str
         ):
         if alchemy_engine is None:
             raise PackageDependencyWarning(
-                'Missing a required python package to run Postgres. '
-                'Please download the Postgres package by running: '
-                'pip install rasgoql[snowflake]')
+                'Missing a required python package to run MySQL. '
+                'Please download the MySQL package by running: '
+                'pip install rasgoql[mysql]')
         self.username = username
         self.password = password
         self.host = host
-        self.port = port
         self.database = database
         self.schema = schema
 
@@ -64,7 +58,6 @@ class PostgresCredentials(DWCredentials):
             {
                 "user": self.username,
                 "host": self.host,
-                "port": self.port,
                 "database": self.database,
                 "schema": self.schema,
             }
@@ -74,27 +67,25 @@ class PostgresCredentials(DWCredentials):
     def from_env(
             cls,
             filepath: str = None
-        ) -> 'PostgresCredentials':
+        ) -> 'MySQLCredentials':
         """
         Creates an instance of this Class from a .env file on your machine
         """
         load_env(filepath)
-        username = os.getenv('POSTGRES_USERNAME')
-        password = os.getenv('POSTGRES_PASSWORD')
-        host = os.getenv('POSTGRES_HOST')
-        port = os.getenv('POSTGRES_PORT')
-        database = os.getenv('POSTGRES_DATABASE')
-        schema = os.getenv('POSTGRES_SCHEMA')
-        if not all([username, password, host, port, database, schema]):
+        username = os.getenv('MYSQL_USERNAME')
+        password = os.getenv('MYSQL_PASSWORD')
+        host = os.getenv('MYSQL_HOST')
+        database = os.getenv('MYSQL_DATABASE')
+        schema = os.getenv('MYSQL_SCHEMA')
+        if not all([username, password, host, database, schema]):
             raise DWCredentialsWarning(
                 'Your env file is missing expected credentials. Consider running '
-                'PostgresCredentials(*args).to_env() to repair this.'
+                'MySQLCredentials(*args).to_env() to repair this.'
             )
         return cls(
             username,
             password,
             host,
-            port,
             database,
             schema
         )
@@ -107,7 +98,6 @@ class PostgresCredentials(DWCredentials):
             "username": self.username,
             "password": self.password,
             "host": self.host,
-            "port": self.port,
             "database": self.database,
             "schema": self.schema,
             "dw_type": self.dw_type
@@ -122,29 +112,24 @@ class PostgresCredentials(DWCredentials):
         Saves credentials to a .env file on your machine
         """
         creds = {
-            "POSTGRES_USERNAME": self.username,
-            "POSTGRES_PASSWORD": self.password,
-            "POSTGRES_HOST": self.host,
-            "POSTGRES_PORT": self.port,
-            "POSTGRES_DATABASE": self.database,
-            "POSTGRES_SCHEMA": self.schema
+            "MYSQL_USERNAME": self.username,
+            "MYSQL_PASSWORD": self.password,
+            "MYSQL_HOST": self.host,
+            "MYSQL_DATABASE": self.database,
+            "MYSQL_SCHEMA": self.schema
         }
         return save_env(creds, filepath, overwrite)
 
 
-class PostgresDataWarehouse(DataWarehouse):
+class MySQLDataWarehouse(SQLAlchemyDataWarehouse):
     """
-    Postgres DataWarehouse
+    MySQL DataWarehouse
     """
-    dw_type = 'postgresql'
-    credentials_class = PostgresCredentials
+    dw_type = 'mysql'
+    credentials_class = MySQLCredentials
 
     def __init__(self):
         super().__init__()
-        self.credentials: dict = None
-        self.connection: alchemy_session = None
-        self.database = None
-        self.schema = None
 
     # ---------------------------
     # Core Data Warehouse methods
@@ -161,13 +146,13 @@ class PostgresDataWarehouse(DataWarehouse):
             namespace (database.schema)
         """
         raise NotImplementedError(
-            "Connecting to a new Database in a single session is not supported by Postgres. "
-            "Please build a new connection using the PostgresCredentials class"
+            "Connecting to a new Database in a single session is not supported by MySQL. "
+            "Please build a new connection using the MySQLCredentials class"
         )
 
     def connect(
             self,
-            credentials: Union[dict, PostgresCredentials]
+            credentials: Union[dict, MySQLCredentials]
         ):
         """
         Connect to Postgres
@@ -176,7 +161,7 @@ class PostgresDataWarehouse(DataWarehouse):
         `credentials`: dict:
             dict (or DWCredentials class) holding the connection credentials
         """
-        if isinstance(credentials, PostgresCredentials):
+        if isinstance(credentials, MySQLCredentials):
             credentials = credentials.to_dict()
 
         try:
@@ -185,22 +170,7 @@ class PostgresDataWarehouse(DataWarehouse):
             self.schema = credentials.get('schema')
             self.connection = alchemy_session(self._engine)
             verbose_message(
-                "Connected to Postgres",
-                logger
-            )
-        except Exception as e:
-            self._error_handler(e)
-
-    def close_connection(self):
-        """
-        Close connection to Postgres
-        """
-        try:
-            if self.connection:
-                self.connection.close()
-            self.connection = None
-            verbose_message(
-                "Connection to Postgres closed",
+                "Connected to MySQL",
                 logger
             )
         except Exception as e:
@@ -231,57 +201,14 @@ class PostgresDataWarehouse(DataWarehouse):
         """
         table_type = check_table_type(table_type)
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
-        schema, table = parse_table_and_schema_from_fqtn(fqtn=fqtn)
         if self._table_exists(fqtn=fqtn) and not overwrite:
             msg = f'A table or view named {fqtn} already exists. ' \
                    'If you are sure you want to overwrite it, ' \
                    'pass in overwrite=True and run this function again'
             raise TableConflictException(msg)
-        query = f"CREATE OR REPLACE {table_type} {schema}.{table} AS {sql}"
+        query = f"CREATE OR REPLACE {table_type} {fqtn} AS {sql}"
         self.execute_query(query, acknowledge_risk=True, response='None')
         return fqtn
-
-    @property
-    def default_namespace(self) -> str:
-        """
-        Returns the default database.schema of this connection
-        """
-        return f'{self.database}.{self.schema}'
-
-    def execute_query(
-            self,
-            sql: str,
-            response: str = 'tuple',
-            acknowledge_risk: bool = False
-        ):
-        """
-        Run a query against Postgres and return all results
-
-        `sql`: str:
-            query text to execute
-        `response`: str:
-            Possible values: [dict, df, None]
-        `acknowledge_risk`: bool:
-            pass True when you know your SQL statement contains
-            a potentially dangerous or data-altering operation
-            and still want to run it against your DataWarehouse
-        """
-        response = check_response_type(response)
-        if is_scary_sql(sql) and not acknowledge_risk:
-            msg = 'It looks like your SQL statement contains a ' \
-                  'potentially dangerous or data-altering operation.' \
-                  'If you are positive you want to run this, ' \
-                  'pass in acknowledge_risk=True and run this function again.'
-            raise SQLWarning(msg)
-        verbose_message(
-            f"Executing query: {sql}",
-            logger
-        )
-        if response == 'DICT':
-            return self._query_into_dict(sql)
-        if response == 'DF':
-            return self._query_into_df(sql)
-        return self._execute_string(sql, ignore_results=(response == 'NONE'))
 
     def get_ddl(
             self,
@@ -295,12 +222,7 @@ class PostgresDataWarehouse(DataWarehouse):
         """
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         _, schema_name, table_name = parse_fqtn(fqtn)
-        sql = (
-            f"select table_schema, table_name, column_name, data_type, "
-            f"character_maximum_length, column_default, is_nullable from "
-            f"INFORMATION_SCHEMA.COLUMNS where table_name = '{table_name}' "
-            f"and table_schema = '{schema_name}';"
-        )
+        sql = f"SHOW CREATE TABLE {schema_name}.{table_name}"
         query_response = self.execute_query(sql, response='DF')
         return query_response
 
@@ -309,7 +231,7 @@ class PostgresDataWarehouse(DataWarehouse):
             fqtn: str
         ) -> tuple:
         """
-        Return details of a table or view in Postgres
+        Return details of a table or view in MySQL
 
         Params:
         `fqtn`: str:
@@ -321,190 +243,16 @@ class PostgresDataWarehouse(DataWarehouse):
             object type: [table|view|unknown]
         """
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
-        database, schema, table = parse_fqtn(fqtn)
-        sql = (
-            f"SELECT EXISTS(SELECT FROM pg_catalog.pg_class c JOIN "
-            f"pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE "
-            f"n.nspname = '{schema}' AND    c.relname = '{table}')"
-        )
+        _, schema, table = parse_fqtn(fqtn)
+        sql = f"SHOW TABLES LIKE '{table}' IN {schema}"
         result = self.execute_query(sql, response='dict')
         obj_exists = len(result) > 0
         is_rasgo_obj = False
         obj_type = 'unknown'
         return obj_exists, is_rasgo_obj, obj_type
 
-    def get_schema(
-            self,
-            fqtn: str,
-            create_sql: str = None
-        ) -> dict:
-        """
-        Return the schema of a table or view
-
-        Params:
-        `fqtn`: str:
-            Fully-qualified table name (database.schema.table)
-        `create_sql`: str:
-            A SQL select statement that will create the view. If this param is passed
-            and the fqtn does not already exist, it will be created and profiled based
-            on this statement. The view will be dropped after profiling
-        """
-        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
-        database, schema, table = parse_fqtn(fqtn)
-        query_sql = f"SELECT * FROM INFORMATION_SCHEMA.TABLES " \
-                    f"WHERE table_catalog = '{database}' " \
-                    f"AND table_schema = '{schema}' " \
-                    f"AND table_name = '{table}'"
-        response = []
-        try:
-            if self._table_exists(fqtn):
-                query_response = self.execute_query(query_sql, response='dict')
-            elif create_sql:
-                self.create(create_sql, fqtn, table_type='view')
-                query_response = self.execute_query(query_sql, response='dict')
-                self.execute_query(f'DROP VIEW {schema}.{table}', response='none', acknowledge_risk=True)
-            else:
-                raise TableAccessError(f'Table {fqtn} does not exist or cannot be accessed.')
-            for row in query_response:
-                response.append((row['name'], row['type']))
-            return response
-        except Exception as e:
-            self._error_handler(e)
-
-    def list_tables(
-            self,
-            database: str = None,
-            schema: str = None
-        ) -> pd.DataFrame:
-        """
-        List all tables and views available in default namespace
-
-        Params:
-        `database`: str:
-            override database
-        `schema`: str:
-            override schema
-        """
-        select_clause = (
-            "SELECT TABLE_NAME, "
-            "TABLE_CATALOG||'.'||TABLE_SCHEMA||'.'||TABLE_NAME AS FQTN, "
-            "CASE TABLE_TYPE WHEN 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS TABLE_TYPE"
-        )
-        from_clause = " FROM INFORMATION_SCHEMA.TABLES "
-        if database:
-            from_clause = f" FROM {database.upper()}.INFORMATION_SCHEMA.TABLES "
-        where_clause = f" WHERE TABLE_SCHEMA = '{schema.upper()}'" if schema else ""
-        sql = select_clause + from_clause + where_clause
-        return self.execute_query(sql, response='df', acknowledge_risk=True)
-
-    def preview(
-            self,
-            sql: str,
-            limit: int = 10
-        ) -> pd.DataFrame:
-        """
-        Returns 10 records into a pandas DataFrame
-
-        Params:
-        `sql`: str:
-            SQL statment to run
-        `limit`: int:
-            Records to return
-        """
-        return self.execute_query(
-            f'{sql} LIMIT {limit}',
-            response='df',
-            acknowledge_risk=True
-        )
-
-    def save_df(
-            self,
-            df: pd.DataFrame,
-            fqtn: str,
-            method: str = None
-        ) -> str:
-        """
-        Creates a table in Postgres from a pandas Dataframe
-
-        Params:
-        `df`: pandas DataFrame:
-            DataFrame to upload
-        `fqtn`: str:
-            Fully-qualied table name (database.schema.table)
-            Name for the new table
-        `method`: str
-            Values: [append, replace]
-            when this table already exists in your DataWarehouse,
-            pass append: to add dataframe rows to it
-            pass replace: to overwrite it with dataframe rows
-                WARNING: This will completely overwrite data in the existing table
-        """
-        if method:
-            method = check_write_method(method)
-        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
-        database, schema, table = parse_fqtn(fqtn)
-        table_exists = self._table_exists(fqtn)
-        if table_exists and not method:
-            msg = f"A table named {fqtn} already exists. " \
-                   "If you are sure you want to write over it, pass in " \
-                   "method='append' or method='replace' and run this function again"
-            raise TableConflictException(msg)
-        try:
-            cleanse_sql_dataframe(df)
-            # If the table does not exist or we've received instruction to replace
-            # Issue a create or replace statement before we insert data
-            if not table_exists or method == 'REPLACE':
-                create_stmt = generate_dataframe_ddl(df, fqtn)
-                self.execute_query(create_stmt, response='None', acknowledge_risk=True)
-            df.to_sql(
-                table,
-                self._engine,
-                schema=schema,
-                if_exists=method.lower(),
-                index=False,
-                chunksize=1000
-            )
-            return fqtn
-        except Exception as e:
-            self._error_handler(e)
-
-    # ---------------------------
-    # Core Data Warehouse helpers
-    # ---------------------------
-    def _table_exists(
-            self,
-            fqtn: str
-        ) -> bool:
-        """
-        Check for existence of fqtn in the Data Warehouse and return a boolean
-
-        Params:
-        `fqtn`: str:
-            Fully-qualified table name (database.schema.table)
-        """
-        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
-        do_i_exist, _, _ = self.get_object_details(fqtn)
-        return do_i_exist
-
-    def _validate_namespace(
-            self,
-            namespace: str
-        ) -> str:
-        """
-        Checks a namespace string for compliance with Postgres format
-
-        Params:
-        `namespace`: str:
-            namespace (database.schema)
-        """
-        try:
-            validate_namespace(namespace)
-            return namespace.upper()
-        except ValueError:
-            raise ParameterException("Postgres namespaces should be format: DATABASE.SCHEMA")
-
     # --------------------------
-    # Postgres specific helpers
+    # MySQL specific helpers
     # --------------------------
     @property
     def _engine(
@@ -513,84 +261,12 @@ class PostgresDataWarehouse(DataWarehouse):
         """
         Returns a SQLAlchemy engine
         """
-        engine_url = f"{self.credentials.get('dw_type')}://" \
-            f"{self.credentials.get('username')}:" \
-            f"{self.credentials.get('password')}" \
-            f"@{self.credentials.get('host')}:" \
-            f"{self.credentials.get('port')}/" \
+        engine_url = (
+            f"{self.credentials.get('dw_type')}"
+            f"+{self.credentials.get('db_api')}://"
+            f"{self.credentials.get('username')}:"
+            f"{self.credentials.get('password')}"
+            f"@{self.credentials.get('host')}/"
             f"{self.credentials.get('database')}"
-        return alchemy_engine(engine_url)
-
-    def _error_handler(
-            self,
-            exception: Exception,
-            query: str = None
-        ) -> None:
-        """
-        Handle Postgres exceptions that need additional info
-        """
-        verbose_message(
-            f"Exception occurred while running query: {query}",
-            logger
         )
-        if exception is None:
-            return
-        if isinstance(exception, alchemy_exceptions.DisconnectionError):
-            raise DWConnectionError(
-                'Disconnected from DataWarehouse. Please validate connection '
-                'or reconnect.'
-            ) from exception
-        raise exception
-
-    def _execute_string(
-            self,
-            query: str,
-            ignore_results: bool = False
-        ) -> List[tuple]:
-        """
-        Execute a query string against the DataWarehouse connection and fetch all results
-        """
-        try:
-            results = self.connection.execute(query)
-            if ignore_results:
-                return
-            return list(results)
-        except Exception as e:
-            self._error_handler(e)
-
-    def _query_into_dict(
-            self,
-            query: str
-        ) -> List[dict]:
-        """
-        Run a query string and return results in a Snowflake DictCursor
-
-        PRO:
-        Results are callable by column name
-        for row in data:
-            row['COL_NAME']
-
-        CON:
-        Query string must be a single statement (only one ;) or Snowflake returns an error
-        """
-        try:
-            query_return = self.connection.execute(query).__dict__
-            return query_return
-        except Exception as e:
-            self._error_handler(e)
-
-    def _query_into_df(
-            self,
-            query: str
-        ) -> pd.DataFrame:
-        """
-        Run a query string and return results in a pandas DataFrame
-        """
-        try:
-            query_result = self.connection.execute(query)
-            query_return_df = pd.DataFrame(query_result.all())
-            response_cols = list(query_result.keys())
-            query_return_df.columns = response_cols
-            return query_return_df
-        except Exception as e:
-            self._error_handler(e)
+        return alchemy_engine(engine_url)

--- a/rasgoql/rasgoql/data/snowflake.py
+++ b/rasgoql/rasgoql/data/snowflake.py
@@ -10,25 +10,34 @@ import pandas as pd
 
 from rasgoql.data.base import DataWarehouse, DWCredentials
 from rasgoql.errors import (
-    DWCredentialsWarning, DWConnectionError, DWQueryError,
-    PackageDependencyWarning, ParameterException,
-    SQLWarning, TableAccessError, TableConflictException
+    DWCredentialsWarning,
+    DWConnectionError,
+    DWQueryError,
+    PackageDependencyWarning,
+    ParameterException,
+    SQLWarning,
+    TableAccessError,
+    TableConflictException,
 )
 from rasgoql.imports import sf_connector, write_pandas
 from rasgoql.primitives.enums import (
-    check_response_type, check_write_method, check_write_table_type
+    check_response_type,
+    check_write_method,
+    check_write_table_type,
 )
 from rasgoql.utils.creds import load_env, save_env
 from rasgoql.utils.df import cleanse_sql_dataframe, generate_dataframe_ddl
 from rasgoql.utils.messaging import verbose_message
 from rasgoql.utils.sql import (
-    is_scary_sql, magic_fqtn_handler,
-    parse_fqtn, parse_namespace,
-    validate_namespace
+    is_scary_sql,
+    magic_fqtn_handler,
+    parse_fqtn,
+    parse_namespace,
+    validate_namespace,
 )
 
 logging.basicConfig()
-logger = logging.getLogger('Snowflake DataWarehouse')
+logger = logging.getLogger("Snowflake DataWarehouse")
 logger.setLevel(logging.INFO)
 
 
@@ -36,23 +45,25 @@ class SnowflakeCredentials(DWCredentials):
     """
     Snowflake Credentials
     """
-    dw_type = 'snowflake'
+
+    dw_type = "snowflake"
 
     def __init__(
-            self,
-            account: str,
-            user: str,
-            password: str,
-            role: str,
-            warehouse: str,
-            database: str,
-            schema: str
-        ):
+        self,
+        account: str,
+        user: str,
+        password: str,
+        role: str,
+        warehouse: str,
+        database: str,
+        schema: str,
+    ):
         if sf_connector is None:
             raise PackageDependencyWarning(
-                'Missing a required python package to run Snowflake. '
-                'Please download the Snowflake package by running: '
-                'pip install rasgoql[snowflake]')
+                "Missing a required python package to run Snowflake. "
+                "Please download the Snowflake package by running: "
+                "pip install rasgoql[snowflake]"
+            )
         self.account = account
         self.user = user
         self.password = password
@@ -74,35 +85,24 @@ class SnowflakeCredentials(DWCredentials):
         )
 
     @classmethod
-    def from_env(
-            cls,
-            filepath: str = None
-        ) -> 'SnowflakeCredentials':
+    def from_env(cls, filepath: str = None) -> "SnowflakeCredentials":
         """
         Creates an instance of this Class from a .env file on your machine
         """
         load_env(filepath)
-        account = os.getenv('SNOWFLAKE_ACCOUNT')
-        user = os.getenv('SNOWFLAKE_USER')
-        password = os.getenv('SNOWFLAKE_PASSWORD')
-        role = os.getenv('SNOWFLAKE_ROLE')
-        warehouse = os.getenv('SNOWFLAKE_WAREHOUSE')
-        database = os.getenv('SNOWFLAKE_DATABASE')
-        schema = os.getenv('SNOWFLAKE_SCHEMA')
+        account = os.getenv("SNOWFLAKE_ACCOUNT")
+        user = os.getenv("SNOWFLAKE_USER")
+        password = os.getenv("SNOWFLAKE_PASSWORD")
+        role = os.getenv("SNOWFLAKE_ROLE")
+        warehouse = os.getenv("SNOWFLAKE_WAREHOUSE")
+        database = os.getenv("SNOWFLAKE_DATABASE")
+        schema = os.getenv("SNOWFLAKE_SCHEMA")
         if not all([account, user, password, role, warehouse, database, schema]):
             raise DWCredentialsWarning(
-                'Your env file is missing expected credentials. Consider running '
-                'SnowflakeCredentials(*args).to_env() to repair this.'
+                "Your env file is missing expected credentials. Consider running "
+                "SnowflakeCredentials(*args).to_env() to repair this."
             )
-        return cls(
-            account,
-            user,
-            password,
-            role,
-            warehouse,
-            database,
-            schema
-        )
+        return cls(account, user, password, role, warehouse, database, schema)
 
     def to_dict(self) -> dict:
         """
@@ -115,14 +115,10 @@ class SnowflakeCredentials(DWCredentials):
             "role": self.role,
             "warehouse": self.warehouse,
             "database": self.database,
-            "schema": self.schema
+            "schema": self.schema,
         }
 
-    def to_env(
-            self,
-            filepath: str = None,
-            overwrite: bool = False
-        ):
+    def to_env(self, filepath: str = None, overwrite: bool = False):
         """
         Saves credentials to a .env file on your machine
         """
@@ -142,7 +138,8 @@ class SnowflakeDataWarehouse(DataWarehouse):
     """
     Snowflake DataWarehouse
     """
-    dw_type = 'snowflake'
+
+    dw_type = "snowflake"
     credentials_class = SnowflakeCredentials
 
     def __init__(self):
@@ -155,10 +152,7 @@ class SnowflakeDataWarehouse(DataWarehouse):
     # ---------------------------
     # Core Data Warehouse methods
     # ---------------------------
-    def change_namespace(
-            self,
-            namespace: str
-        ) -> None:
+    def change_namespace(self, namespace: str) -> None:
         """
         Changes the default namespace of your connection
 
@@ -169,22 +163,16 @@ class SnowflakeDataWarehouse(DataWarehouse):
         namespace = self._validate_namespace(namespace)
         database, schema = parse_namespace(namespace)
         try:
-            self.execute_query(f'USE DATABASE {database}')
-            self.execute_query(f'USE SCHEMA {schema}')
+            self.execute_query(f"USE DATABASE {database}")
+            self.execute_query(f"USE SCHEMA {schema}")
             self.default_namespace = namespace
             self.default_database = database
             self.default_schema = schema
-            verbose_message(
-                f"Namespace reset to {self.default_namespace}",
-                logger
-            )
+            verbose_message(f"Namespace reset to {self.default_namespace}", logger)
         except Exception as e:
             self._error_handler(e)
 
-    def connect(
-            self,
-            credentials: Union[dict, SnowflakeCredentials]
-        ):
+    def connect(self, credentials: Union[dict, SnowflakeCredentials]):
         """
         Connect to Snowflake
 
@@ -196,21 +184,15 @@ class SnowflakeDataWarehouse(DataWarehouse):
             credentials = credentials.to_dict()
 
         # This allows you to track what queries were run by RasgoQL in your history tab
-        credentials.update({
-            "application": "rasgoql",
-            "session_parameters": {
-                "QUERY_TAG": "rasgoql"
-            }
-        })
+        credentials.update(
+            {"application": "rasgoql", "session_parameters": {"QUERY_TAG": "rasgoql"}}
+        )
         try:
             self.credentials = credentials
-            self.default_database = credentials.get('database')
-            self.default_schema = credentials.get('schema')
+            self.default_database = credentials.get("database")
+            self.default_schema = credentials.get("schema")
             self.connection = sf_connector.connect(**credentials)
-            verbose_message(
-                "Connected to Snowflake",
-                logger
-            )
+            verbose_message("Connected to Snowflake", logger)
         except Exception as e:
             self._error_handler(e)
 
@@ -222,20 +204,13 @@ class SnowflakeDataWarehouse(DataWarehouse):
             if self.connection:
                 self.connection.close()
             self.connection = None
-            verbose_message(
-                "Connection to Snowflake closed",
-                logger
-            )
+            verbose_message("Connection to Snowflake closed", logger)
         except Exception as e:
             self._error_handler(e)
 
     def create(
-            self,
-            sql: str,
-            fqtn: str,
-            table_type: str = 'VIEW',
-            overwrite: bool = False
-        ):
+        self, sql: str, fqtn: str, table_type: str = "VIEW", overwrite: bool = False
+    ):
         """
         Create a view or table from given SQL
 
@@ -255,12 +230,14 @@ class SnowflakeDataWarehouse(DataWarehouse):
         table_type = check_write_table_type(table_type)
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         if self._table_exists(fqtn) and not overwrite:
-            msg = f'A table or view named {fqtn} already exists. ' \
-                   'If you are sure you want to overwrite it, ' \
-                   'pass in overwrite=True and run this function again'
+            msg = (
+                f"A table or view named {fqtn} already exists. "
+                "If you are sure you want to overwrite it, "
+                "pass in overwrite=True and run this function again"
+            )
             raise TableConflictException(msg)
         query = f"CREATE OR REPLACE {table_type} {fqtn} COMMENT='rasgoql' AS {sql}"
-        self.execute_query(query, acknowledge_risk=True, response='None')
+        self.execute_query(query, acknowledge_risk=True, response="None")
         return fqtn
 
     @property
@@ -268,14 +245,11 @@ class SnowflakeDataWarehouse(DataWarehouse):
         """
         Returns the default database.schema of this connection
         """
-        return f'{self.default_database}.{self.default_schema}'
+        return f"{self.default_database}.{self.default_schema}"
 
     def execute_query(
-            self,
-            sql: str,
-            response: str = 'tuple',
-            acknowledge_risk: bool = False
-        ):
+        self, sql: str, response: str = "tuple", acknowledge_risk: bool = False
+    ):
         """
         Run a query against Snowflake and return all results
 
@@ -290,25 +264,21 @@ class SnowflakeDataWarehouse(DataWarehouse):
         """
         response = check_response_type(response)
         if is_scary_sql(sql) and not acknowledge_risk:
-            msg = 'It looks like your SQL statement contains a ' \
-                  'potentially dangerous or data-altering operation.' \
-                  'If you are positive you want to run this, ' \
-                  'pass in acknowledge_risk=True and run this function again.'
+            msg = (
+                "It looks like your SQL statement contains a "
+                "potentially dangerous or data-altering operation."
+                "If you are positive you want to run this, "
+                "pass in acknowledge_risk=True and run this function again."
+            )
             raise SQLWarning(msg)
-        verbose_message(
-            f"Executing query: {sql}",
-            logger
-        )
-        if response == 'DICT':
+        verbose_message(f"Executing query: {sql}", logger)
+        if response == "DICT":
             return self._execute_dict_cursor(sql)
-        if response == 'DF':
+        if response == "DF":
             return self._execute_df_cursor(sql)
-        return self._execute_string(sql, ignore_results=(response == 'NONE'))
+        return self._execute_string(sql, ignore_results=(response == "NONE"))
 
-    def get_ddl(
-            self,
-            fqtn: str
-        ) -> str:
+    def get_ddl(self, fqtn: str) -> str:
         """
         Returns the create statement for a table or view
 
@@ -317,13 +287,10 @@ class SnowflakeDataWarehouse(DataWarehouse):
         """
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         sql = f"SELECT GET_DDL('TABLE', '{fqtn}') AS DDL"
-        query_response = self.execute_query(sql, response='dict')
-        return query_response[0]['DDL']
+        query_response = self.execute_query(sql, response="dict")
+        return query_response[0]["DDL"]
 
-    def get_object_details(
-            self,
-            fqtn: str
-        ) -> tuple:
+    def get_object_details(self, fqtn: str) -> tuple:
         """
         Return details of a table or view in Snowflake
 
@@ -339,20 +306,16 @@ class SnowflakeDataWarehouse(DataWarehouse):
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         database, schema, table = parse_fqtn(fqtn)
         sql = f"SHOW OBJECTS LIKE '{table}' IN {database}.{schema}"
-        result = self.execute_query(sql, response='dict')
+        result = self.execute_query(sql, response="dict")
         obj_exists = len(result) > 0
         is_rasgo_obj = False
-        obj_type = 'unknown'
+        obj_type = "unknown"
         if obj_exists:
-            is_rasgo_obj = (result[0].get('comment') == 'rasgoql')
-            obj_type = result[0].get('kind')
+            is_rasgo_obj = result[0].get("comment") == "rasgoql"
+            obj_type = result[0].get("kind")
         return obj_exists, is_rasgo_obj, obj_type
 
-    def get_schema(
-            self,
-            fqtn: str,
-            create_sql: str = None
-        ) -> dict:
+    def get_schema(self, fqtn: str, create_sql: str = None) -> dict:
         """
         Return the schema of a table or view
 
@@ -369,24 +332,24 @@ class SnowflakeDataWarehouse(DataWarehouse):
         response = []
         try:
             if self._table_exists(fqtn):
-                query_response = self.execute_query(desc_sql, response='dict')
+                query_response = self.execute_query(desc_sql, response="dict")
             elif create_sql:
-                self.create(create_sql, fqtn, table_type='view')
-                query_response = self.execute_query(desc_sql, response='dict')
-                self.execute_query(f'DROP VIEW {fqtn}', response='none', acknowledge_risk=True)
+                self.create(create_sql, fqtn, table_type="view")
+                query_response = self.execute_query(desc_sql, response="dict")
+                self.execute_query(
+                    f"DROP VIEW {fqtn}", response="none", acknowledge_risk=True
+                )
             else:
-                raise TableAccessError(f'Table {fqtn} does not exist or cannot be accessed.')
+                raise TableAccessError(
+                    f"Table {fqtn} does not exist or cannot be accessed."
+                )
             for row in query_response:
-                response.append((row['name'], row['type']))
+                response.append((row["name"], row["type"]))
             return response
         except Exception as e:
             self._error_handler(e)
 
-    def list_tables(
-            self,
-            database: str = None,
-            schema: str = None
-        ) -> pd.DataFrame:
+    def list_tables(self, database: str = None, schema: str = None) -> pd.DataFrame:
         """
         List all tables and views available in default namespace
 
@@ -396,22 +359,20 @@ class SnowflakeDataWarehouse(DataWarehouse):
         `schema`: str:
             override schema
         """
-        select_clause = "SELECT TABLE_NAME, " \
-                        "TABLE_CATALOG||'.'||TABLE_SCHEMA||'.'||TABLE_NAME AS FQTN, " \
-                        "CASE TABLE_TYPE WHEN 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS TABLE_TYPE, " \
-                        "ROW_COUNT, CREATED, LAST_ALTERED "
+        select_clause = (
+            "SELECT TABLE_NAME, "
+            "TABLE_CATALOG||'.'||TABLE_SCHEMA||'.'||TABLE_NAME AS FQTN, "
+            "CASE TABLE_TYPE WHEN 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS TABLE_TYPE, "
+            "ROW_COUNT, CREATED, LAST_ALTERED "
+        )
         from_clause = " FROM INFORMATION_SCHEMA.TABLES "
         if database:
             from_clause = f" FROM {database.upper()}.INFORMATION_SCHEMA.TABLES "
         where_clause = f" WHERE TABLE_SCHEMA = '{schema.upper()}'" if schema else ""
         sql = select_clause + from_clause + where_clause
-        return self.execute_query(sql, response='df', acknowledge_risk=True)
+        return self.execute_query(sql, response="df", acknowledge_risk=True)
 
-    def preview(
-            self,
-            sql: str,
-            limit: int = 10
-        ) -> pd.DataFrame:
+    def preview(self, sql: str, limit: int = 10) -> pd.DataFrame:
         """
         Returns 10 records into a pandas DataFrame
 
@@ -422,17 +383,10 @@ class SnowflakeDataWarehouse(DataWarehouse):
             Records to return
         """
         return self.execute_query(
-            f'{sql} LIMIT {limit}',
-            response='df',
-            acknowledge_risk=True
+            f"{sql} LIMIT {limit}", response="df", acknowledge_risk=True
         )
 
-    def save_df(
-            self,
-            df: pd.DataFrame,
-            fqtn: str,
-            method: str = None
-        ) -> str:
+    def save_df(self, df: pd.DataFrame, fqtn: str, method: str = None) -> str:
         """
         Creates a table in Snowflake from a pandas Dataframe
 
@@ -454,23 +408,22 @@ class SnowflakeDataWarehouse(DataWarehouse):
         fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
         table_exists = self._table_exists(fqtn)
         if table_exists and not method:
-            msg = f"A table named {fqtn} already exists. " \
-                   "If you are sure you want to write over it, pass in " \
-                   "method='append' or method='replace' and run this function again"
+            msg = (
+                f"A table named {fqtn} already exists. "
+                "If you are sure you want to write over it, pass in "
+                "method='append' or method='replace' and run this function again"
+            )
             raise TableConflictException(msg)
         try:
             cleanse_sql_dataframe(df)
             # If the table does not exist or we've received instruction to replace
             # Issue a create or replace statement before we insert data
-            if not table_exists or method == 'REPLACE':
+            if not table_exists or method == "REPLACE":
                 create_stmt = generate_dataframe_ddl(df, fqtn)
                 create_stmt += " COMMENT='rasgoql' "
-                self.execute_query(create_stmt, response='None', acknowledge_risk=True)
+                self.execute_query(create_stmt, response="None", acknowledge_risk=True)
             _success, _chunks, _rows, _output = write_pandas(
-                conn=self.connection,
-                df=df,
-                table_name=fqtn,
-                quote_identifiers=False
+                conn=self.connection, df=df, table_name=fqtn, quote_identifiers=False
             )
             return fqtn
         except Exception as e:
@@ -479,10 +432,7 @@ class SnowflakeDataWarehouse(DataWarehouse):
     # ---------------------------
     # Core Data Warehouse helpers
     # ---------------------------
-    def _table_exists(
-            self,
-            fqtn: str
-        ) -> bool:
+    def _table_exists(self, fqtn: str) -> bool:
         """
         Check for existence of fqtn in the Data Warehouse and return a boolean
 
@@ -494,10 +444,7 @@ class SnowflakeDataWarehouse(DataWarehouse):
         do_i_exist, _, _ = self.get_object_details(fqtn)
         return do_i_exist
 
-    def _validate_namespace(
-            self,
-            namespace: str
-        ) -> str:
+    def _validate_namespace(self, namespace: str) -> str:
         """
         Checks a namespace string for compliance with Snowflake format
 
@@ -509,53 +456,45 @@ class SnowflakeDataWarehouse(DataWarehouse):
             validate_namespace(namespace)
             return namespace.upper()
         except ValueError:
-            raise ParameterException("Snowflake namespaces should be format: DATABASE.SCHEMA")
+            raise ParameterException(
+                "Snowflake namespaces should be format: DATABASE.SCHEMA"
+            )
 
     # --------------------------
     # Snowflake specific helpers
     # --------------------------
-    def _error_handler(
-            self,
-            exception: Exception,
-            query: str = None
-        ) -> None:
+    def _error_handler(self, exception: Exception, query: str = None) -> None:
         """
         Handle Snowflake exceptions that need additional info
         """
-        verbose_message(
-            f"Exception occurred while running query: {query}",
-            logger
-        )
+        verbose_message(f"Exception occurred while running query: {query}", logger)
         if exception is None:
             return
         if isinstance(exception, sf_connector.errors.ProgrammingError):
             if exception.errno == 3001:
                 raise TableAccessError(
-                    'You do not have access to operate on this object. '
-                    'Two possible ways to resolve: '
-                    'Connect with different credentials that have the proper access. '
-                    'Or run `.change_namespace` on your SQLChain to write it to a '
-                    'namespace your credentials can access'
+                    "You do not have access to operate on this object. "
+                    "Two possible ways to resolve: "
+                    "Connect with different credentials that have the proper access. "
+                    "Or run `.change_namespace` on your SQLChain to write it to a "
+                    "namespace your credentials can access"
                 ) from exception
         if isinstance(exception, sf_connector.errors.DatabaseError):
             if exception.errno == 250001:
                 raise DWConnectionError(
-                    'Invalid username / password, please check that your '
-                    'credentials are correct and try to reconnect.'
+                    "Invalid username / password, please check that your "
+                    "credentials are correct and try to reconnect."
                 ) from exception
         if isinstance(exception, sf_connector.errors.ServiceUnavailableError):
             raise DWConnectionError(
-                'Snowflake is unavailable. Please check that your are using '
-                'a valid account identifier, that you have internet access, and '
-                'that http connections to Snowflake are whitelisted in your env. '
-                'Finally check https://status.snowflake.com/ for outage status.'
+                "Snowflake is unavailable. Please check that your are using "
+                "a valid account identifier, that you have internet access, and "
+                "that http connections to Snowflake are whitelisted in your env. "
+                "Finally check https://status.snowflake.com/ for outage status."
             ) from exception
         raise exception
 
-    def _execute_dict_cursor(
-            self,
-            query: str
-        ) -> List[dict]:
+    def _execute_dict_cursor(self, query: str) -> List[dict]:
         """
         Run a query string and return results in a Snowflake DictCursor
 
@@ -579,10 +518,8 @@ class SnowflakeDataWarehouse(DataWarehouse):
                 cursor.close()
 
     def _execute_df_cursor(
-            self,
-            query: str,
-            params: Optional[dict] = None
-        ) -> pd.DataFrame:
+        self, query: str, params: Optional[dict] = None
+    ) -> pd.DataFrame:
         """
         Run a query string and return results in a pandas DataFrame
         """
@@ -597,18 +534,16 @@ class SnowflakeDataWarehouse(DataWarehouse):
             if cursor:
                 cursor.close()
 
-    def _execute_string(
-            self,
-            query: str,
-            ignore_results: bool = False
-        ) -> List[tuple]:
+    def _execute_string(self, query: str, ignore_results: bool = False) -> List[tuple]:
         """
         Execute a query string against the Data Warehouse connection and fetch all results
         """
         query_returns = []
         cursor = None
         try:
-            for cursor in self.connection.execute_string(query, return_cursors=(not ignore_results)):
+            for cursor in self.connection.execute_string(
+                query, return_cursors=(not ignore_results)
+            ):
                 for query_return in cursor:
                     query_returns.append(query_return)
             return query_returns

--- a/rasgoql/rasgoql/data/sqlalchemy.py
+++ b/rasgoql/rasgoql/data/sqlalchemy.py
@@ -24,7 +24,7 @@ from rasgoql.utils.messaging import verbose_message
 from rasgoql.utils.sql import (
     is_scary_sql, magic_fqtn_handler,
     parse_fqtn, parse_table_and_schema_from_fqtn,
-    validate_namespace
+    validate_namespace, parse_namespace
 )
 
 logging.basicConfig()
@@ -137,6 +137,7 @@ class SQLAlchemyDataWarehouse(DataWarehouse):
     # ---------------------------
     # Core Data Warehouse methods
     # ---------------------------
+    # TODO: some DBs use Database, some use Schema. What's the best way to abstract?
     def change_namespace(
             self,
             namespace: str

--- a/rasgoql/rasgoql/data/sqlalchemy.py
+++ b/rasgoql/rasgoql/data/sqlalchemy.py
@@ -4,6 +4,7 @@ Generic SQLAlchemy DataWarehouse classes
 from abc import abstractmethod
 import logging
 from typing import List
+from urllib.parse import quote_plus as urlquote
 
 import pandas as pd
 
@@ -406,7 +407,7 @@ class SQLAlchemyDataWarehouse(DataWarehouse):
         engine_url = (
             f"{self.credentials.get('dw_type')}://"
             f"{self.credentials.get('username')}:"
-            f"{self.credentials.get('password')}"
+            f"{urlquote(self.credentials.get('password'))}"
             f"@{self.credentials.get('host')}:"
             f"{self.credentials.get('port')}/"
             f"{self.credentials.get('database')}"

--- a/rasgoql/rasgoql/utils/sql.py
+++ b/rasgoql/rasgoql/utils/sql.py
@@ -135,6 +135,9 @@ def parse_namespace(namespace: str, strict: bool = True) -> tuple:
     if strict:
         namespace = validate_namespace(namespace)
         return tuple(namespace.split("."))
+    if namespace.count(".") == 1:
+        namespace = validate_namespace(namespace)
+        return tuple(namespace.split("."))
     if namespace.count(".") == 0:
         return (namespace, None)
 

--- a/rasgoql/rasgoql/utils/sql.py
+++ b/rasgoql/rasgoql/utils/sql.py
@@ -1,14 +1,14 @@
 """
 Helpful sql utilities
 """
+from email.policy import default
+from multiprocessing.sharedctypes import Value
 import random
 import re
 import string
 
 
-def cleanse_sql_data_type(
-        dtype: str
-    ) -> str:
+def cleanse_sql_data_type(dtype: str) -> str:
     """
     Converts pandas data types to SQL compliant data type
     """
@@ -17,17 +17,15 @@ def cleanse_sql_data_type(
     else:
         return dtype.lower()
 
-def cleanse_sql_name(
-        name: str
-) -> str:
+
+def cleanse_sql_name(name: str) -> str:
     """
     Converts a string to a SQL compliant value
     """
-    return name.replace(" ", "_").replace("-", "_").replace('"', '').replace(".", "_")
+    return name.replace(" ", "_").replace("-", "_").replace('"', "").replace(".", "_")
 
-def is_scary_sql(
-        sql: str
-) -> bool:
+
+def is_scary_sql(sql: str) -> bool:
     """
     Checks a SQL string for presence of injection keywords
     """
@@ -35,9 +33,8 @@ def is_scary_sql(
         return True
     return False
 
-def is_restricted_sql(
-        sql: str
-) -> bool:
+
+def is_restricted_sql(sql: str) -> bool:
     """
     Checks a SQL string for presence of dangerous keywords
     """
@@ -45,138 +42,249 @@ def is_restricted_sql(
         return True
     return False
 
-def magic_fqtn_handler(
-        possible_fqtn: str,
-        default_namespace: str
-    ) -> str:
+
+def magic_fqtn_handler(possible_fqtn: str, default_namespace: str) -> str:
     """
     Makes all of your wildest dreams come true... well not *that* one
     """
     input_db, input_schema, table = parse_fqtn(possible_fqtn, default_namespace, False)
-    default_database, default_schema = parse_namespace(default_namespace)
+    default_database, default_schema = parse_namespace(default_namespace, False)
     database = input_db or default_database
     schema = input_schema or default_schema
     return make_fqtn(database, schema, table)
 
-def make_fqtn(
-        database: str,
-        schema: str,
-        table: str
-) -> str:
+
+def make_fqtn(database: str, schema: str, table: str) -> str:
     """
     Accepts component parts and returns a fully qualified table string
     """
-    return f"{database}.{schema}.{table}"
+    if database and schema and table:
+        return f"{database}.{schema}.{table}"
+    elif database and table:
+        return f"{database}.{table}"
+    elif schema and table:
+        return f"{schema}.{table}"
+    else:
+        raise ValueError(f"Cannot make an FQTN out of\n{database}\n{schema}\n{table}")
 
-def make_namespace_from_fqtn(
-        fqtn: str
-) -> str:
+
+def make_namespace_from_fqtn(fqtn: str, default_namespace: str = None) -> str:
     """
     Accepts component parts and returns a fully qualified namespace string
     """
-    database, schema, _ = parse_fqtn(fqtn)
-    return f"{database}.{schema}"
+    database, schema, table = parse_fqtn(
+        fqtn, default_namespace=default_namespace, strict=False
+    )
+    if database and schema:
+        return f"{database}.{schema}"
+    elif database:
+        return database
+    elif schema:
+        return schema
+    else:
+        raise ValueError(
+            f"Attempting to parse FQTN {fqtn} has resulted in either a missing "
+            "database or a missing schema. Please ensure that your FQTN is more "
+            f"than just a table name.\nDatabase: {database}\nSchema: {schema}"
+        )
 
-def parse_fqtn(
-        fqtn: str,
-        default_namespace: str = None,
-        strict: bool = True
-) -> tuple:
+
+def parse_fqtn(fqtn: str, default_namespace: str = None, strict: bool = True) -> tuple:
     """
     Accepts a possible fully qualified table string and returns its component parts
     """
     if strict:
         fqtn = validate_fqtn(fqtn)
-        return (* fqtn.split("."),)
+        return (*fqtn.split("."),)
+    if default_namespace and "." not in default_namespace:
+        # If we get a default_namespace without a '.' we assume that the
+        # supported datawarehouse expects a namespace not composed of a
+        # DB.Schema, but instead only one of them
+        if fqtn.count(".") == 1:
+            if default_namespace and fqtn.split(".")[0] != default_namespace:
+                # If we get only one '.' in an FQTN, we should assume that the
+                # selected DataWarehosue expects to either get only a schema
+                # or database included in the FQTN. If this is true, the default
+                # namespace passed here should match the first half of the FQTN
+                # TODO: error message
+                raise ValueError(
+                    f"default_namespace passed as {default_namespace}, which "
+                    f"should match the first half of FQTN {fqtn}. Please "
+                    "validate values"
+                )
+            r = (*fqtn.split("."),)
+            r = r[:1] + (None,) + r[1:]
+            return r
     database, schema = parse_namespace(default_namespace)
     if fqtn.count(".") == 2:
-        return (* fqtn.split("."),)
+        return (*fqtn.split("."),)
     if fqtn.count(".") == 1:
-        return (database, * fqtn.split("."),)
+        return (
+            database,
+            *fqtn.split("."),
+        )
     if fqtn.count(".") == 0:
         return (database, schema, fqtn)
-    raise ValueError(f'{fqtn} is not a well-formed fqtn')
+    raise ValueError(f"{fqtn} is not a well-formed fqtn")
 
-def parse_namespace(
-        namespace: str
-) -> tuple:
+
+def parse_namespace(namespace: str, strict: bool = True) -> tuple:
     """
     Accepts a possible namespace string and returns its component parts
     """
-    namespace = validate_namespace(namespace)
-    return tuple(namespace.split("."))
+    if strict:
+        namespace = validate_namespace(namespace)
+        return tuple(namespace.split("."))
+    if namespace.count(".") == 0:
+        return (namespace, None)
 
-def parse_table_and_schema_from_fqtn(
-    fqtn: str
-) -> tuple:
+
+def parse_table_and_schema_from_fqtn(fqtn: str) -> tuple:
     """
     Accepts a possible FQTN and returns the schema and table from it
     """
     fqtn = validate_fqtn(fqtn)
     return tuple(fqtn.split(".")[1:])
 
+
 def random_table_name() -> str:
     """
     Returns a random unique table name prefixed with "RQL"
     """
-    return 'RQL_'+''.join(random.choice(string.ascii_uppercase) for x in range(10))
+    return "RQL_" + "".join(random.choice(string.ascii_uppercase) for x in range(10))
 
-def validate_fqtn(
-        fqtn: str
-    ) -> str:
+
+def validate_fqtn(fqtn: str) -> str:
     """
     Accepts a possible fully qualified table string and decides whether it is well formed
     """
-    if re.match(r'^[^\s]+\.[^\s]+\.[^\s]+', fqtn):
+    if re.match(r"^[^\s]+\.[^\s]+\.[^\s]+", fqtn):
         return fqtn
-    raise ValueError(f'{fqtn} is not a well-formed fqtn')
+    raise ValueError(f"{fqtn} is not a well-formed fqtn")
 
-def validate_namespace(
-        namespace: str
-    ) -> bool:
+
+def validate_namespace(namespace: str) -> bool:
     """
     Accepts a possible namespace string and decides whether it is well formed
     """
-    if re.match(r'^[^\s]+\.[^\s]+', namespace):
+    if re.match(r"^[^\s]+\.[^\s]+", namespace):
         return namespace
-    raise ValueError(f'{namespace} is not a well-formed namespace')
+    raise ValueError(f"{namespace} is not a well-formed namespace")
 
-def wrap_table(
-        parent_table: str
-    )-> str:
+
+def wrap_table(parent_table: str) -> str:
     """
     Calculates a unique table string
     """
-    prefix = 'RQL'
-    suffix = ''.join(random.choice(string.ascii_uppercase) for x in range(5))
-    if parent_table.startswith('RQL'):
+    prefix = "RQL"
+    suffix = "".join(random.choice(string.ascii_uppercase) for x in range(5))
+    if parent_table.startswith("RQL"):
         return f"{parent_table}_{suffix}"
     return f"{prefix}_{parent_table}_{suffix}"
 
 
-SQL_RESTRICTED_CHARACTERS = [
-    ' ', '-', ';'
-]
+SQL_RESTRICTED_CHARACTERS = [" ", "-", ";"]
 
 SQL_INJECTION_KEYWORDS = [
-    'DELETE',
-    'TRUNCATE',
-    'DROP',
-    'ALTER',
-    'UPDATE',
-    'INSERT',
-    'MERGE'
+    "DELETE",
+    "TRUNCATE",
+    "DROP",
+    "ALTER",
+    "UPDATE",
+    "INSERT",
+    "MERGE",
 ]
 
 SQL_RESTRICTED_KEYWORDS = [
-    'ACCOUNT', 'ALL', 'ALTER', 'AND', 'ANY', 'AS', 'BETWEEN', 'BY',
-    'CASE', 'CAST', 'CHECK', 'COLUMN', 'CONNECT', 'CONNECTION', 'CONSTRAINT',
-    'CREATE', 'CROSS', 'CURRENT', 'CURRENT_DATE', 'CURRENT_TIME', 'CURRENT_TIMESTAMP',
-    'CURRENT_USER', 'DATABASE', 'DELETE', 'DISTINCT', 'DROP', 'ELSE', 'EXISTS', 'FALSE',
-    'FOLLOWING', 'FOR', 'FROM', 'FULL', 'GRANT', 'GROUP', 'GSCLUSTER', 'HAVING', 'ILIKE',
-    'IN', 'INCREMENT', 'INNER', 'INSERT', 'INTERSECT', 'INTO', 'IS', 'ISSUE', 'JOIN', 'LATERAL',
-    'LEFT', 'LIKE', 'LOCALTIME', 'LOCALTIMESTAMP', 'MINUS', 'NATURAL', 'NOT', 'NULL', 'OF', 'ON',
-    'OR', 'ORDER', 'ORGANIZATION', 'QUALIFY', 'REGEXP', 'REVOKE', 'RIGHT', 'RLIKE', 'ROW', 'ROWS',
-    'SAMPLE', 'SCHEMA', 'SELECT', 'SET', 'SOME', 'START', 'TABLE', 'TABLESAMPLE', 'THEN', 'TO', 'TRIGGER',
-    'TRUE', 'TRY_CAST', 'UNION', 'UNIQUE', 'UPDATE', 'USING', 'VALUES', 'VIEW', 'WHEN', 'WHENEVER', 'WHERE', 'WITH'
+    "ACCOUNT",
+    "ALL",
+    "ALTER",
+    "AND",
+    "ANY",
+    "AS",
+    "BETWEEN",
+    "BY",
+    "CASE",
+    "CAST",
+    "CHECK",
+    "COLUMN",
+    "CONNECT",
+    "CONNECTION",
+    "CONSTRAINT",
+    "CREATE",
+    "CROSS",
+    "CURRENT",
+    "CURRENT_DATE",
+    "CURRENT_TIME",
+    "CURRENT_TIMESTAMP",
+    "CURRENT_USER",
+    "DATABASE",
+    "DELETE",
+    "DISTINCT",
+    "DROP",
+    "ELSE",
+    "EXISTS",
+    "FALSE",
+    "FOLLOWING",
+    "FOR",
+    "FROM",
+    "FULL",
+    "GRANT",
+    "GROUP",
+    "GSCLUSTER",
+    "HAVING",
+    "ILIKE",
+    "IN",
+    "INCREMENT",
+    "INNER",
+    "INSERT",
+    "INTERSECT",
+    "INTO",
+    "IS",
+    "ISSUE",
+    "JOIN",
+    "LATERAL",
+    "LEFT",
+    "LIKE",
+    "LOCALTIME",
+    "LOCALTIMESTAMP",
+    "MINUS",
+    "NATURAL",
+    "NOT",
+    "NULL",
+    "OF",
+    "ON",
+    "OR",
+    "ORDER",
+    "ORGANIZATION",
+    "QUALIFY",
+    "REGEXP",
+    "REVOKE",
+    "RIGHT",
+    "RLIKE",
+    "ROW",
+    "ROWS",
+    "SAMPLE",
+    "SCHEMA",
+    "SELECT",
+    "SET",
+    "SOME",
+    "START",
+    "TABLE",
+    "TABLESAMPLE",
+    "THEN",
+    "TO",
+    "TRIGGER",
+    "TRUE",
+    "TRY_CAST",
+    "UNION",
+    "UNIQUE",
+    "UPDATE",
+    "USING",
+    "VALUES",
+    "VIEW",
+    "WHEN",
+    "WHENEVER",
+    "WHERE",
+    "WITH",
 ]

--- a/rasgoql/requirements-mysql.txt
+++ b/rasgoql/requirements-mysql.txt
@@ -1,2 +1,2 @@
 SQLAlchemy
-psycopg2
+pymysql

--- a/rasgoql/setup.py
+++ b/rasgoql/setup.py
@@ -9,68 +9,63 @@ from rasgoql.version import __version__
 _here = os.path.abspath(os.path.dirname(__file__))
 
 
-with open(os.path.join(_here, 'DESCRIPTION.md'), encoding='utf-8') as f:
+with open(os.path.join(_here, "DESCRIPTION.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-with open(os.path.join(_here, 'requirements.txt'), encoding='utf-8') as f:
+with open(os.path.join(_here, "requirements.txt"), encoding="utf-8") as f:
     req_lines = f.read()
     requirements = req_lines.splitlines()
 
-with open(os.path.join(_here, 'requirements-snowflake.txt'), encoding='utf-8') as f:
+with open(os.path.join(_here, "requirements-snowflake.txt"), encoding="utf-8") as f:
     req_lines = f.read()
     sf_requirements = req_lines.splitlines()
 
-with open(os.path.join(_here, 'requirements-bigquery.txt'), encoding='utf-8') as f:
+with open(os.path.join(_here, "requirements-bigquery.txt"), encoding="utf-8") as f:
     req_lines = f.read()
     bq_requirements = req_lines.splitlines()
 
-with open(os.path.join(_here, 'requirements-postgres.txt'), encoding='utf-8') as f:
+with open(os.path.join(_here, "requirements-postgres.txt"), encoding="utf-8") as f:
     req_lines = f.read()
     postgres_requirements = req_lines.splitlines()
 
-with open(os.path.join(_here, 'requirements-mysql.txt'), encoding='utf-8') as f:
-    req_lines = f.reat()
+with open(os.path.join(_here, "requirements-mysql.txt"), encoding="utf-8") as f:
+    req_lines = f.read()
     mysql_requirements = req_lines.splitlines()
 
 setup(
-    name='rasgoql',
+    name="rasgoql",
     version=__version__,
-    description=('Alpha version of rasgoQL open-source package.'),
+    description=("Alpha version of rasgoQL open-source package."),
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Rasgo Intelligence',
-    author_email='patrick@rasgoml.com',
+    long_description_content_type="text/markdown",
+    author="Rasgo Intelligence",
+    author_email="patrick@rasgoml.com",
     project_urls={
-        'Documentation': 'https://docs.rasgoql.com',
-        'Source': 'https://github.com/rasgointelligence/RasgoQL',
-        'Rasgo': 'https://www.rasgoml.com/',
+        "Documentation": "https://docs.rasgoql.com",
+        "Source": "https://github.com/rasgointelligence/RasgoQL",
+        "Rasgo": "https://www.rasgoml.com/",
     },
-    license='GNU Affero General Public License v3 or later (AGPLv3+)',
-    packages=[
-        'rasgoql',
-        'rasgoql.data',
-        'rasgoql.primitives',
-        'rasgoql.utils'
-        ],
+    license="GNU Affero General Public License v3 or later (AGPLv3+)",
+    packages=["rasgoql", "rasgoql.data", "rasgoql.primitives", "rasgoql.utils"],
     install_requires=requirements,
     extras_require={
-        "snowflake":  sf_requirements,
+        "snowflake": sf_requirements,
         "bigquery": bq_requirements,
         "postgres": postgres_requirements,
         "mysql": mysql_requirements,
     },
     include_package_data=True,
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Database',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: Software Development :: Code Generators'
-        ]
+        "Development Status :: 2 - Pre-Alpha",
+        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Database",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Software Development :: Code Generators",
+    ],
 )

--- a/rasgoql/setup.py
+++ b/rasgoql/setup.py
@@ -28,6 +28,10 @@ with open(os.path.join(_here, 'requirements-postgres.txt'), encoding='utf-8') as
     req_lines = f.read()
     postgres_requirements = req_lines.splitlines()
 
+with open(os.path.join(_here, 'requirements-mysql.txt'), encoding='utf-8') as f:
+    req_lines = f.reat()
+    mysql_requirements = req_lines.splitlines()
+
 setup(
     name='rasgoql',
     version=__version__,
@@ -52,7 +56,8 @@ setup(
     extras_require={
         "snowflake":  sf_requirements,
         "bigquery": bq_requirements,
-        "postgres": postgres_requirements
+        "postgres": postgres_requirements,
+        "mysql": mysql_requirements,
     },
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
This PR closes #46 . Adding DB support for MySQL by:
1. Generalizing a base class for all connections derived from SQLAlchemy
2. Modifying the existing Postgres DataWarehouse class to use the new SQLAlchemy base class
3. Creating a MySQL DataWarehouse class that utilizes some MySQL specific SQL syntax that significantly easy DDL checking operations.