### PR TITLE
Add fqtn warning on SQLchains

### DIFF
--- a/rasgoql/rasgoql/primitives/transforms.py
+++ b/rasgoql/rasgoql/primitives/transforms.py
@@ -303,7 +303,12 @@ class SQLChain(TransformableClass):
         NOTE: This property will be dynamic until the Chain is finally saved
         """
         if self.ternimal_transform:
-            return Dataset(self.ternimal_transform.fqtn, self._dw)
+            fqtn = self.ternimal_transform.fqtn
+            chn_logger.warning(
+                f'{fqtn} does not yet exist in your database. '
+                'To create it run .save() on this SQLChain.'
+            )
+            return Dataset(fqtn, self._dw)
         return self.entry_table
 
     @require_dw


### PR DESCRIPTION
Add a helpful warning message to SQLChains to eliminate user confusion about in memory objects vs tables/views.