### PR TITLE
changes for pandas batches from snowflake

### DIFF
--- a/rasgoql/rasgoql/data/base.py
+++ b/rasgoql/rasgoql/data/base.py
@@ -117,7 +117,8 @@ class DataWarehouse(ABC):
             self,
             sql: str,
             response: str = 'tuple',
-            acknowledge_risk: bool = False
+            acknowledge_risk: bool = False,
+            batches: bool = False
         ):
         """
         Run a query against this DataWarehouse

--- a/rasgoql/rasgoql/data/bigquery.py
+++ b/rasgoql/rasgoql/data/bigquery.py
@@ -262,7 +262,8 @@ class BigQueryDataWarehouse(DataWarehouse):
             self,
             sql: str,
             response: str = 'tuple',
-            acknowledge_risk: bool = False
+            acknowledge_risk: bool = False,
+            batches: bool = False
         ):
         """
         Run a query against BigQuery and return all results

--- a/rasgoql/rasgoql/data/postgres.py
+++ b/rasgoql/rasgoql/data/postgres.py
@@ -252,7 +252,8 @@ class PostgresDataWarehouse(DataWarehouse):
             self,
             sql: str,
             response: str = 'tuple',
-            acknowledge_risk: bool = False
+            acknowledge_risk: bool = False,
+            batches: bool = False
         ):
         """
         Run a query against Postgres and return all results

--- a/rasgoql/rasgoql/main.py
+++ b/rasgoql/rasgoql/main.py
@@ -111,12 +111,18 @@ class RasgoQL:
     def query_into_df(
             self,
             sql: str,
-            acknowledge_risk: bool = False
+            acknowledge_risk: bool = False,
+            batches: bool = False
         ) -> pd.DataFrame:
         """
         Execute a query against your Data Warehouse and return results in a pandas DataFrame
         """
-        return self._dw.execute_query(sql, response='df', acknowledge_risk=acknowledge_risk)
+        return self._dw.execute_query(
+            sql,
+            response='df',
+            acknowledge_risk=acknowledge_risk,
+            batches=batches
+        )
 
     def set_verbose(
             self,

--- a/rasgoql/rasgoql/primitives/transforms.py
+++ b/rasgoql/rasgoql/primitives/transforms.py
@@ -171,11 +171,13 @@ class Dataset(TransformableClass):
 
     @require_dw
     @require_materialized
-    def to_df(self) -> pd.DataFrame:
+    def to_df(self, batches=False) -> pd.DataFrame:
         """
         Return a pandas DataFrame of the entire table
         """
-        return self._dw.execute_query(f"SELECT * FROM {self.fqtn}", response='df')
+        return self._dw.execute_query(
+            f"SELECT * FROM {self.fqtn}", response='df', batches=batches
+        )
 
 
 class TransformTemplate:
@@ -408,8 +410,10 @@ class SQLChain(TransformableClass):
             include_schema
         )
 
-    def to_df(self) -> pd.DataFrame:
+    def to_df(self, batches: bool = False) -> pd.DataFrame:
         """
         Returns data into a pandas DataFrame
         """
-        return self._dw.execute_query(self.sql(), response='df')
+        return self._dw.execute_query(
+            self.sql(), response='df', batches=batches
+        )

--- a/rasgoql/rasgoql/primitives/transforms.py
+++ b/rasgoql/rasgoql/primitives/transforms.py
@@ -176,7 +176,9 @@ class Dataset(TransformableClass):
         Return a pandas DataFrame of the entire table
         """
         return self._dw.execute_query(
-            f"SELECT * FROM {self.fqtn}", response='df', batches=batches
+            f"SELECT * FROM {self.fqtn}",
+            response='df',
+            batches=batches
         )
 
 
@@ -415,5 +417,7 @@ class SQLChain(TransformableClass):
         Returns data into a pandas DataFrame
         """
         return self._dw.execute_query(
-            self.sql(), response='df', batches=batches
+            self.sql(),
+            response='df',
+            batches=batches
         )


### PR DESCRIPTION
Adding support for transform and dataset `to_df()` method to return batches of dataframes from Snowflake. Added the same functionality for `rql.query_into_df()`.

This parameter will only functionally change calls to Snowflake, but method signature changes are needed on other DWs so that we don't break calls.