### PR TITLE
Let's support MySQL in RasgoQL

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a parameter to allow batch returning of Pandas DataFrames from `to_df()` and `query_into_df()` methods
 
+## [1.3.0] - 2022-03-25
+### Added
+- Added support for MySQL
+
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/
@@ -68,3 +72,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://pypi.org/project/rasgoql/1.1.0/
 [1.1.1]: https://pypi.org/project/rasgoql/1.1.1/
 [1.2.0]: https://pypi.org/project/rasgoql/1.2.0/
+[1.3.0]: https://pypi.org/project/rasgoql/1.3.0/

--- a/rasgoql/DESCRIPTION.md
+++ b/rasgoql/DESCRIPTION.md
@@ -56,6 +56,9 @@ https://docs.rasgoql.com
 
 - v1.2.0 (Mar 24, 2022)
     - Added a parameter to allow batch returning of Pandas DataFrames from `to_df()` and `query_into_df()` methods
+  
+- v1.3.0 (Mar 25, 2022)
+    - Added support for MySQL
 
 
 See [Changelog](https://github.com/rasgointelligence/RasgoQL/blob/main/rasgoql/CHANGELOG.md) for full minor version release notes

--- a/rasgoql/rasgoql/__init__.py
+++ b/rasgoql/rasgoql/__init__.py
@@ -9,7 +9,8 @@ from rasgoql.data import (
     DWCredentials,
     BigQueryCredentials, BigQueryDataWarehouse,
     SnowflakeCredentials, SnowflakeDataWarehouse,
-    PostgresCredentials, PostgresDataWarehouse
+    PostgresCredentials, PostgresDataWarehouse,
+    MySQLCredentials, MySQLDataWarehouse
 )
 from rasgoql.errors import ParameterException
 from rasgoql.main import RasgoQL
@@ -25,6 +26,7 @@ DW_MAP = {
     'snowflake': SnowflakeDataWarehouse,
     'bigquery': BigQueryDataWarehouse,
     'postgresql': PostgresDataWarehouse,
+    "mysql": MySQLDataWarehouse,
 }
 
 

--- a/rasgoql/rasgoql/data/__init__.py
+++ b/rasgoql/rasgoql/data/__init__.py
@@ -2,3 +2,4 @@ from rasgoql.data.base import DataWarehouse, DWCredentials
 from rasgoql.data.bigquery import BigQueryDataWarehouse, BigQueryCredentials
 from rasgoql.data.snowflake import SnowflakeDataWarehouse, SnowflakeCredentials
 from rasgoql.data.postgres import PostgresCredentials, PostgresDataWarehouse
+from rasgoql.data.mysql import MySQLCredentials, MySQLDataWarehouse

--- a/rasgoql/rasgoql/data/base.py
+++ b/rasgoql/rasgoql/data/base.py
@@ -64,13 +64,40 @@ class DataWarehouse(ABC):
     # ---------------------------
     # FQTN and namespace methods
     # ---------------------------
-    def validate_fqtn(self, fqtn: str) -> str:
+    def magic_fqtn_handler(
+        self,
+        possible_fqtn: str,
+        default_namespace: str
+    ) -> str:
         """
-        Accepts a possible fully qualified table string and decides whether it is well formed
+        Makes all of your wildest dreams come true... well not *that* one
         """
-        if re.match(r'^[^\s]+\.[^\s]+\.[^\s]+', fqtn):
-            return fqtn
-        raise ValueError(f'{fqtn} is not a well-formed fqtn')
+        input_db, input_schema, table = self.parse_fqtn(possible_fqtn, default_namespace, False)
+        default_database, default_schema = self.parse_namespace(default_namespace)
+        database = input_db or default_database
+        schema = input_schema or default_schema
+        return self.make_fqtn(database, schema, table)
+
+    def make_fqtn(
+        self,
+        database: str,
+        schema: str,
+        table: str
+    ) -> str:
+        """
+        Accepts component parts and returns a fully qualified table string
+        """
+        return f"{database}.{schema}.{table}"
+
+    def make_namespace_from_fqtn(
+        self,
+        fqtn: str
+    ) -> str:
+        """
+        Accepts component parts and returns a fully qualified namespace string
+        """
+        database, schema, _ = self.parse_fqtn(fqtn)
+        return f"{database}.{schema}"
 
     def parse_fqtn(
         self,
@@ -94,30 +121,23 @@ class DataWarehouse(ABC):
             return (database, schema, fqtn)
         raise ValueError(f'{fqtn} is not a well-formed fqtn')
 
-    def make_fqtn(
+    def parse_namespace(
         self,
-        database: str,
-        schema: str,
-        table: str
-    ) -> str:
+        namespace: str
+    ) -> tuple:
         """
-        Accepts component parts and returns a fully qualified table string
+        Accepts a possible namespace string and returns its component parts
         """
-        return f"{database}.{schema}.{table}"
+        namespace = self.validate_namespace(namespace)
+        return tuple(namespace.split("."))
 
-    def magic_fqtn_handler(
-        self,
-        possible_fqtn: str,
-        default_namespace: str
-    ) -> str:
+    def validate_fqtn(self, fqtn: str) -> str:
         """
-        Makes all of your wildest dreams come true... well not *that* one
+        Accepts a possible fully qualified table string and decides whether it is well formed
         """
-        input_db, input_schema, table = self.parse_fqtn(possible_fqtn, default_namespace, False)
-        default_database, default_schema = self.parse_namespace(default_namespace)
-        database = input_db or default_database
-        schema = input_schema or default_schema
-        return self.make_fqtn(database, schema, table)
+        if re.match(r'^[^\s]+\.[^\s]+\.[^\s]+', fqtn):
+            return fqtn
+        raise ValueError(f'{fqtn} is not a well-formed fqtn')
 
     def validate_namespace(
         self,
@@ -129,26 +149,6 @@ class DataWarehouse(ABC):
         if re.match(r'^[^\s]+\.[^\s]+', namespace):
             return namespace
         raise ValueError(f'{namespace} is not a well-formed namespace')
-
-    def parse_namespace(
-        self,
-        namespace: str
-    ) -> tuple:
-        """
-        Accepts a possible namespace string and returns its component parts
-        """
-        namespace = self.validate_namespace(namespace)
-        return tuple(namespace.split("."))
-
-    def make_namespace_from_fqtn(
-        self,
-        fqtn: str
-    ) -> str:
-        """
-        Accepts component parts and returns a fully qualified namespace string
-        """
-        database, schema, _ = self.parse_fqtn(fqtn)
-        return f"{database}.{schema}"
 
     # Core methods
 

--- a/rasgoql/rasgoql/data/base.py
+++ b/rasgoql/rasgoql/data/base.py
@@ -2,6 +2,7 @@
 Base DataWarehouse classes
 """
 from abc import ABC
+import re
 from typing import Union
 
 import pandas as pd
@@ -59,6 +60,97 @@ class DataWarehouse(ABC):
     def __init__(self):
         self.credentials = None
         self.connection = None
+
+    # ---------------------------
+    # FQTN and namespace methods
+    # ---------------------------
+    def validate_fqtn(self, fqtn: str) -> str:
+        """
+        Accepts a possible fully qualified table string and decides whether it is well formed
+        """
+        if re.match(r'^[^\s]+\.[^\s]+\.[^\s]+', fqtn):
+            return fqtn
+        raise ValueError(f'{fqtn} is not a well-formed fqtn')
+
+    def parse_fqtn(
+        self,
+        fqtn: str,
+        default_namespace: str = None,
+        strict: bool = True
+    ) -> tuple:
+        """
+        Accepts a possible fully qualified table string and returns its component parts
+        """
+        # TODO: review the logic of this method
+        if strict:
+            fqtn = self.validate_fqtn(fqtn)
+            return (* fqtn.split("."),)
+        database, schema = self.parse_namespace(default_namespace)
+        if fqtn.count(".") == 2:
+            return (* fqtn.split("."),)
+        if fqtn.count(".") == 1:
+            return (database, * fqtn.split("."),)
+        if fqtn.count(".") == 0:
+            return (database, schema, fqtn)
+        raise ValueError(f'{fqtn} is not a well-formed fqtn')
+
+    def make_fqtn(
+        self,
+        database: str,
+        schema: str,
+        table: str
+    ) -> str:
+        """
+        Accepts component parts and returns a fully qualified table string
+        """
+        return f"{database}.{schema}.{table}"
+
+    def magic_fqtn_handler(
+        self,
+        possible_fqtn: str,
+        default_namespace: str
+    ) -> str:
+        """
+        Makes all of your wildest dreams come true... well not *that* one
+        """
+        input_db, input_schema, table = self.parse_fqtn(possible_fqtn, default_namespace, False)
+        default_database, default_schema = self.parse_namespace(default_namespace)
+        database = input_db or default_database
+        schema = input_schema or default_schema
+        return self.make_fqtn(database, schema, table)
+
+    def validate_namespace(
+        self,
+        namespace: str
+    ) -> bool:
+        """
+        Accepts a possible namespace string and decides whether it is well formed
+        """
+        if re.match(r'^[^\s]+\.[^\s]+', namespace):
+            return namespace
+        raise ValueError(f'{namespace} is not a well-formed namespace')
+
+    def parse_namespace(
+        self,
+        namespace: str
+    ) -> tuple:
+        """
+        Accepts a possible namespace string and returns its component parts
+        """
+        namespace = self.validate_namespace(namespace)
+        return tuple(namespace.split("."))
+
+    def make_namespace_from_fqtn(
+        self,
+        fqtn: str
+    ) -> str:
+        """
+        Accepts component parts and returns a fully qualified namespace string
+        """
+        database, schema, _ = self.parse_fqtn(fqtn)
+        return f"{database}.{schema}"
+
+    # Core methods
 
     def change_namespace(
             self,

--- a/rasgoql/rasgoql/data/sqlalchemy.py
+++ b/rasgoql/rasgoql/data/sqlalchemy.py
@@ -1,0 +1,544 @@
+"""
+Generic SQLAlchemy DataWarehouse classes
+"""
+from abc import abstractmethod
+import logging
+import re
+from typing import List
+from urllib.parse import quote_plus as urlquote
+
+import pandas as pd
+
+from rasgoql.data.base import DataWarehouse
+from rasgoql.errors import (
+    DWConnectionError,
+    ParameterException,
+    SQLWarning,
+    TableAccessError,
+    TableConflictException,
+)
+from rasgoql.imports import alchemy_engine, alchemy_session, alchemy_exceptions
+from rasgoql.primitives.enums import (
+    check_response_type,
+    check_table_type,
+    check_write_method,
+)
+from rasgoql.utils.df import cleanse_sql_dataframe, generate_dataframe_ddl
+from rasgoql.utils.messaging import verbose_message
+from rasgoql.utils.sql import (
+    is_scary_sql,
+    magic_fqtn_handler,
+    parse_fqtn,
+    validate_namespace,
+    parse_namespace,
+)
+
+logging.basicConfig()
+logger = logging.getLogger("SQLAlchemy DataWarehouse")
+logger.setLevel(logging.INFO)
+
+
+# Each DB derived from the generic SQLAlchemy class will have slightly
+# different connection strings. Build a unique Credentials class for each DB
+
+
+class SQLAlchemyDataWarehouse(DataWarehouse):
+    """
+    Base SQLAlchemy DataWarehouse
+    """
+
+    dw_type = None
+    credentials_class = None
+
+    def __init__(self):
+        super().__init__()
+        self.credentials: dict = None
+        self.connection: alchemy_session = None
+        self.database = None
+        self.schema = None
+
+    # ---------------------------
+    # FQTN and namespace methods
+    # ---------------------------
+    def validate_fqtn(self, fqtn: str) -> str:
+        """
+        Accepts a possible fully qualified table string and decides whether it is well formed
+        """
+        if re.match(r'^[^\s]+\.[^\s]+\.[^\s]+', fqtn):
+            return fqtn
+        raise ValueError(f'{fqtn} is not a well-formed fqtn')
+
+    def parse_fqtn(
+        self,
+        fqtn: str,
+        default_namespace: str = None,
+        strict: bool = True
+    ) -> tuple:
+        """
+        Accepts a possible fully qualified table string and returns its component parts
+        """
+        # TODO: review the logic of this method
+        if strict:
+            fqtn = self.validate_fqtn(fqtn)
+            return (* fqtn.split("."),)
+        database, schema = self.parse_namespace(default_namespace)
+        if fqtn.count(".") == 2:
+            return (* fqtn.split("."),)
+        if fqtn.count(".") == 1:
+            return (database, * fqtn.split("."),)
+        if fqtn.count(".") == 0:
+            return (database, schema, fqtn)
+        raise ValueError(f'{fqtn} is not a well-formed fqtn')
+
+    def make_fqtn(
+        self,
+        database: str,
+        schema: str,
+        table: str
+    ) -> str:
+        """
+        Accepts component parts and returns a fully qualified table string
+        """
+        return f"{database}.{schema}.{table}"
+
+    def magic_fqtn_handler(
+        self,
+        possible_fqtn: str,
+        default_namespace: str
+    ) -> str:
+        """
+        Makes all of your wildest dreams come true... well not *that* one
+        """
+        input_db, input_schema, table = self.parse_fqtn(possible_fqtn, default_namespace, False)
+        default_database, default_schema = self.parse_namespace(default_namespace)
+        database = input_db or default_database
+        schema = input_schema or default_schema
+        return self.make_fqtn(database, schema, table)
+
+    def validate_namespace(
+        self,
+        namespace: str
+    ) -> bool:
+        """
+        Accepts a possible namespace string and decides whether it is well formed
+        """
+        if re.match(r'^[^\s]+\.[^\s]+', namespace):
+            return namespace
+        raise ValueError(f'{namespace} is not a well-formed namespace')
+
+    def parse_namespace(
+        self,
+        namespace: str
+    ) -> tuple:
+        """
+        Accepts a possible namespace string and returns its component parts
+        """
+        namespace = self.validate_namespace(namespace)
+        return tuple(namespace.split("."))
+
+    def make_namespace_from_fqtn(
+        self,
+        fqtn: str
+    ) -> str:
+        """
+        Accepts component parts and returns a fully qualified namespace string
+        """
+        database, schema, _ = self.parse_fqtn(fqtn)
+        return f"{database}.{schema}"
+
+    # ---------------------------
+    # Core Data Warehouse methods
+    # ---------------------------
+    def change_namespace(self, namespace: str) -> None:
+        """
+        Changes the default namespace of your connection
+        Params:
+        `namespace`: str:
+            namespace (database.schema)
+        """
+        namespace = self._validate_namespace(namespace)
+        database, schema = parse_namespace(namespace)
+        try:
+            self.execute_query(f"USE DATABASE {database}")
+            self.execute_query(f"USE SCHEMA {schema}")
+            self.default_namespace = namespace
+            self.default_database = database
+            self.default_schema = schema
+            verbose_message(f"Namespace reset to {self.default_namespace}", logger)
+        except Exception as e:
+            self._error_handler(e)
+
+    @abstractmethod
+    def connect(self, credentials: dict):
+        """
+        Connect to DB
+        Params:
+        `credentials`: dict:
+            dict  holding the connection credentials
+        """
+        try:
+            self.credentials = credentials
+            self.database = credentials.get("database")
+            self.schema = credentials.get("schema")
+            self.connection = alchemy_session(self._engine)
+            verbose_message("Connected to DB", logger)
+        except Exception as e:
+            self._error_handler(e)
+
+    def close_connection(self):
+        """
+        Close connection
+        """
+        try:
+            if self.connection:
+                self.connection.close()
+            self.connection = None
+            verbose_message("Connection closed", logger)
+        except Exception as e:
+            self._error_handler(e)
+
+    def create(
+        self, sql: str, fqtn: str, table_type: str = "VIEW", overwrite: bool = False
+    ):
+        """
+        Create a view or table from given SQL
+        If a derived class's DB cannot execute against a FQTN (e.g., Postgres),
+        override this method or SQL execution will fail
+        Params:
+        `sql`: str:
+            query that returns data (i.e. can be wrapped in a CREATE TABLE statement)
+        `fqtn`: str:
+            Fully-qualified table name (database.schema.table)
+            Name for the new table
+        `table_type`: str:
+            One of values: [view, table]
+        `overwrite`: bool
+            pass True when this table name already exists in your DataWarehouse
+            and you know you want to overwrite it
+            WARNING: This will completely overwrite data in the existing table
+        """
+        table_type = check_table_type(table_type)
+        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
+        if self._table_exists(fqtn=fqtn) and not overwrite:
+            msg = (
+                f"A table or view named {fqtn} already exists. "
+                "If you are sure you want to overwrite it, "
+                "pass in overwrite=True and run this function again"
+            )
+            raise TableConflictException(msg)
+        query = f"CREATE OR REPLACE {table_type} {fqtn} AS {sql}"
+        self.execute_query(query, acknowledge_risk=True, response="None")
+        return fqtn
+
+    @property
+    def default_namespace(self) -> str:
+        """
+        Returns the default database.schema of this connection
+        """
+        return f"{self.database}.{self.schema}"
+
+    @default_namespace.setter
+    def default_namespace(self, new_namespace: str):
+        namespace = self._validate_namespace(new_namespace)
+        db, schema = parse_namespace(namespace)
+        self.default_database = db
+        self.default_schema = schema
+
+    def execute_query(
+        self, sql: str, response: str = "tuple", acknowledge_risk: bool = False
+    ):
+        """
+        Run a query against DB and return all results
+        `sql`: str:
+            query text to execute
+        `response`: str:
+            Possible values: [dict, df, None]
+        `acknowledge_risk`: bool:
+            pass True when you know your SQL statement contains
+            a potentially dangerous or data-altering operation
+            and still want to run it against your DataWarehouse
+        """
+        response = check_response_type(response)
+        if is_scary_sql(sql) and not acknowledge_risk:
+            msg = (
+                "It looks like your SQL statement contains a "
+                "potentially dangerous or data-altering operation."
+                "If you are positive you want to run this, "
+                "pass in acknowledge_risk=True and run this function again."
+            )
+            raise SQLWarning(msg)
+        verbose_message(f"Executing query: {sql}", logger)
+        if response == "DICT":
+            return self._query_into_dict(sql)
+        if response == "DF":
+            return self._query_into_df(sql)
+        return self._execute_string(sql, ignore_results=(response == "NONE"))
+
+    @abstractmethod
+    def get_ddl(self, fqtn: str) -> pd.DataFrame:
+        """
+        Returns a DataFrame describing the column in the table
+        This method should be overridden by derived classes since optimal DDL
+        selection will vary by DB type
+        `fqtn`: str:
+            Fully-qualified Table Name (database.schema.table)
+        """
+        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
+        db_name, schema_name, table_name = parse_fqtn(fqtn)
+        sql = (
+            f"select table_schema, table_name, column_name, data_type, "
+            f"character_maximum_length, column_default, is_nullable from "
+            f"INFORMATION_SCHEMA.COLUMNS where table_name = '{table_name}' "
+            f"and table_schema = '{schema_name}';"
+        )
+        query_response = self.execute_query(sql, response="DF")
+        return query_response
+
+    @abstractmethod
+    def get_object_details(self, fqtn: str) -> tuple:
+        """
+        Return details of a table or view
+        This method should be overridden by derived classes since optimal DDL
+        selection will vary by DB type
+        Params:
+        `fqtn`: str:
+            Fully-qualified table name (database.schema.table)
+        Response:
+            object exists: bool
+            is rasgo object: bool
+            object type: [table|view|unknown]
+        """
+        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
+        database, schema, table = parse_fqtn(fqtn)
+        sql = f"SHOW OBJECTS LIKE '{table}' IN {database}.{schema}"
+        result = self.execute_query(sql, response="dict")
+        obj_exists = len(result) > 0
+        is_rasgo_obj = False
+        obj_type = "unknown"
+        if obj_exists:
+            is_rasgo_obj = result[0].get("comment") == "rasgoql"
+            obj_type = result[0].get("kind")
+        return obj_exists, is_rasgo_obj, obj_type
+
+    def get_schema(self, fqtn: str, create_sql: str = None) -> dict:
+        """
+        Return the schema of a table or view
+        Params:
+        `fqtn`: str:
+            Fully-qualified table name (database.schema.table)
+        `create_sql`: str:
+            A SQL select statement that will create the view. If this param is passed
+            and the fqtn does not already exist, it will be created and profiled based
+            on this statement. The view will be dropped after profiling
+        """
+        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
+        database, schema, table = parse_fqtn(fqtn)
+        query_sql = (
+            f"SELECT * FROM INFORMATION_SCHEMA.TABLES "
+            f"WHERE table_catalog = '{database}' "
+            f"AND table_schema = '{schema}' "
+            f"AND table_name = '{table}'"
+        )
+        response = []
+        try:
+            if self._table_exists(fqtn):
+                query_response = self.execute_query(query_sql, response="dict")
+            elif create_sql:
+                self.create(create_sql, fqtn, table_type="view")
+                query_response = self.execute_query(query_sql, response="dict")
+                self.execute_query(
+                    f"DROP VIEW {schema}.{table}",
+                    response="none",
+                    acknowledge_risk=True,
+                )
+            else:
+                raise TableAccessError(
+                    f"Table {fqtn} does not exist or cannot be accessed."
+                )
+            for row in query_response:
+                response.append((row["name"], row["type"]))
+            return response
+        except Exception as e:
+            self._error_handler(e)
+
+    def list_tables(self, database: str = None, schema: str = None) -> pd.DataFrame:
+        """
+        List all tables and views available in default namespace
+        Params:
+        `database`: str:
+            override database
+        `schema`: str:
+            override schema
+        """
+        select_clause = (
+            "SELECT TABLE_NAME, "
+            "TABLE_CATALOG||'.'||TABLE_SCHEMA||'.'||TABLE_NAME AS FQTN, "
+            "CASE TABLE_TYPE WHEN 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END AS TABLE_TYPE"
+        )
+        from_clause = " FROM INFORMATION_SCHEMA.TABLES "
+        if database:
+            from_clause = f" FROM {database.upper()}.INFORMATION_SCHEMA.TABLES "
+        where_clause = f" WHERE TABLE_SCHEMA = '{schema.upper()}'" if schema else ""
+        sql = select_clause + from_clause + where_clause
+        return self.execute_query(sql, response="df", acknowledge_risk=True)
+
+    def preview(self, sql: str, limit: int = 10) -> pd.DataFrame:
+        """
+        Returns 10 records into a pandas DataFrame
+        Params:
+        `sql`: str:
+            SQL statment to run
+        `limit`: int:
+            Records to return
+        """
+        return self.execute_query(
+            f"{sql} LIMIT {limit}", response="df", acknowledge_risk=True
+        )
+
+    def save_df(self, df: pd.DataFrame, fqtn: str, method: str = None) -> str:
+        """
+        Creates a table from a pandas Dataframe
+        Params:
+        `df`: pandas DataFrame:
+            DataFrame to upload
+        `fqtn`: str:
+            Fully-qualied table name (database.schema.table)
+            Name for the new table
+        `method`: str
+            Values: [append, replace]
+            when this table already exists in your DataWarehouse,
+            pass append: to add dataframe rows to it
+            pass replace: to overwrite it with dataframe rows
+                WARNING: This will completely overwrite data in the existing table
+        """
+        if method:
+            method = check_write_method(method)
+        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
+        database, schema, table = parse_fqtn(fqtn)
+        table_exists = self._table_exists(fqtn)
+        if table_exists and not method:
+            msg = (
+                f"A table named {fqtn} already exists. "
+                "If you are sure you want to write over it, pass in "
+                "method='append' or method='replace' and run this function again"
+            )
+            raise TableConflictException(msg)
+        try:
+            cleanse_sql_dataframe(df)
+            # If the table does not exist or we've received instruction to replace
+            # Issue a create or replace statement before we insert data
+            if not table_exists or method == "REPLACE":
+                create_stmt = generate_dataframe_ddl(df, fqtn)
+                self.execute_query(create_stmt, response="None", acknowledge_risk=True)
+            df.to_sql(
+                table,
+                self._engine,
+                schema=schema,
+                if_exists=method.lower(),
+                index=False,
+                chunksize=1000,
+            )
+            return fqtn
+        except Exception as e:
+            self._error_handler(e)
+
+    # ---------------------------
+    # Core Data Warehouse helpers
+    # ---------------------------
+    def _table_exists(self, fqtn: str) -> bool:
+        """
+        Check for existence of fqtn in the Data Warehouse and return a boolean
+        Params:
+        `fqtn`: str:
+            Fully-qualified table name (database.schema.table)
+        """
+        fqtn = magic_fqtn_handler(fqtn, self.default_namespace)
+        do_i_exist, _, _ = self.get_object_details(fqtn)
+        return do_i_exist
+
+    def _validate_namespace(self, namespace: str) -> str:
+        """
+        Checks a namespace string for compliance with required format
+        Params:
+        `namespace`: str:
+            namespace (database.schema)
+        """
+        try:
+            validate_namespace(namespace)
+            return namespace.upper()
+        except ValueError:
+            raise ParameterException("Namespaces should be format: DATABASE.SCHEMA")
+
+    # --------------------------
+    # SQLAlchemy and derived class helpers
+    # --------------------------
+    @property
+    @abstractmethod
+    def _engine(self):
+        """
+        Returns a SQLAlchemy engine
+        """
+        engine_url = (
+            f"{self.credentials.get('dw_type')}://"
+            f"{self.credentials.get('username')}:"
+            f"{urlquote(self.credentials.get('password'))}"
+            f"@{self.credentials.get('host')}:"
+            f"{self.credentials.get('port')}/"
+            f"{self.credentials.get('database')}"
+        )
+        return alchemy_engine(engine_url)
+
+    def _error_handler(self, exception: Exception, query: str = None) -> None:
+        """
+        Handle SQLAlchemy exceptions that need additional info
+        """
+        verbose_message(f"Exception occurred while running query: {query}", logger)
+        if exception is None:
+            return
+        if isinstance(exception, alchemy_exceptions.DisconnectionError):
+            raise DWConnectionError(
+                "Disconnected from DataWarehouse. Please validate connection "
+                "or reconnect."
+            ) from exception
+        raise exception
+
+    def _execute_string(self, query: str, ignore_results: bool = False) -> List[tuple]:
+        """
+        Execute a query string against the DataWarehouse connection and fetch all results
+        """
+        try:
+            results = self.connection.execute(query)
+            if ignore_results:
+                return
+            return list(results)
+        except Exception as e:
+            self._error_handler(e)
+
+    def _query_into_dict(self, query: str) -> List[dict]:
+        """
+        Run a query string and return results in a Snowflake DictCursor
+        PRO:
+        Results are callable by column name
+        for row in data:
+            row['COL_NAME']
+        CON:
+        Query string must be a single statement (only one ;) or Snowflake returns an error
+        """
+        try:
+            query_return = self.connection.execute(query).__dict__
+            return query_return
+        except Exception as e:
+            self._error_handler(e)
+
+    def _query_into_df(self, query: str) -> pd.DataFrame:
+        """
+        Run
+        """
+        try:
+            query_result = self.connection.execute(query)
+            query_return_df = pd.DataFrame(query_result.all())
+            response_cols = list(query_result.keys())
+            query_return_df.columns = response_cols
+            return query_return_df
+        except Exception as e:
+            self._error_handler(e)

--- a/rasgoql/rasgoql/primitives/transforms.py
+++ b/rasgoql/rasgoql/primitives/transforms.py
@@ -116,7 +116,7 @@ class Dataset(TransformableClass):
         super().__init__(dw)
         try:
             self.fqtn: str = self._dw.validate_fqtn(fqtn)
-            self.table_name: str = self._dw.parse_fqtn(fqtn)[2]
+            self.table_name: str = self._dw.parse_fqtn(fqtn)[-1]
             self.namespace: str = self._dw.make_namespace_from_fqtn(fqtn)
             self._dw.validate_namespace(self.namespace)
         except ValueError:

--- a/rasgoql/rasgoql/primitives/transforms.py
+++ b/rasgoql/rasgoql/primitives/transforms.py
@@ -8,14 +8,6 @@ import pandas as pd
 import rasgotransforms as rtx
 
 from rasgoql.errors import ParameterException
-from rasgoql.utils.decorators import (
-    beta, require_dw,
-    require_materialized, require_transforms
-)
-from rasgoql.utils.sql import (
-    parse_fqtn, make_namespace_from_fqtn,
-    random_table_name, validate_fqtn
-)
 from rasgoql.primitives.enums import (
     check_render_method, check_table_type, check_write_table_type,
     TableType, TableState
@@ -24,6 +16,11 @@ from rasgoql.primitives.rendering import (
     assemble_cte_chain, assemble_view_chain, create_dbt_files,
     _gen_udt_func_docstring, _gen_udt_func_signature
 )
+from rasgoql.utils.decorators import (
+    beta, require_dw,
+    require_materialized, require_transforms
+)
+from rasgoql.utils.sql import random_table_name
 
 logging.basicConfig()
 ds_logger = logging.getLogger('Dataset')
@@ -118,10 +115,10 @@ class Dataset(TransformableClass):
         ):
         super().__init__(dw)
         try:
-            self.fqtn: str = validate_fqtn(fqtn)
-            self.table_name: str = parse_fqtn(fqtn)[2]
-            self.namespace: str = make_namespace_from_fqtn(fqtn)
-            self._dw._validate_namespace(self.namespace)
+            self.fqtn: str = self._dw.validate_fqtn(fqtn)
+            self.table_name: str = self._dw.parse_fqtn(fqtn)[2]
+            self.namespace: str = self._dw.make_namespace_from_fqtn(fqtn)
+            self._dw.validate_namespace(self.namespace)
         except ValueError:
             raise ParameterException("Must pass in a valid 'fqtn' parameter to create a Dataset")
         self.table_type: str = TableType.UNKNOWN.value

--- a/rasgoql/rasgoql/utils/sql.py
+++ b/rasgoql/rasgoql/utils/sql.py
@@ -49,11 +49,32 @@ def is_restricted_sql(
     return False
 
 
+def parse_namespace(
+    namespace: str
+) -> tuple:
+    """
+    Accepts a possible namespace string and returns its component parts
+    """
+    namespace = validate_namespace(namespace)
+    return tuple(namespace.split("."))
+
+
 def random_table_name() -> str:
     """
     Returns a random unique table name prefixed with "RQL"
     """
     return 'RQL_'+''.join(random.choice(string.ascii_uppercase) for x in range(10))
+
+
+def validate_namespace(
+    namespace: str
+) -> bool:
+    """
+    Accepts a possible namespace string and decides whether it is well formed
+    """
+    if re.match(r'^[^\s]+\.[^\s]+', namespace):
+        return namespace
+    raise ValueError(f'{namespace} is not a well-formed namespace')
 
 
 def wrap_table(

--- a/rasgoql/rasgoql/utils/sql.py
+++ b/rasgoql/rasgoql/utils/sql.py
@@ -17,6 +17,7 @@ def cleanse_sql_data_type(
     else:
         return dtype.lower()
 
+
 def cleanse_sql_name(
         name: str
 ) -> str:
@@ -24,6 +25,7 @@ def cleanse_sql_name(
     Converts a string to a SQL compliant value
     """
     return name.replace(" ", "_").replace("-", "_").replace('"', '').replace(".", "_")
+
 
 def is_scary_sql(
         sql: str
@@ -35,6 +37,7 @@ def is_scary_sql(
         return True
     return False
 
+
 def is_restricted_sql(
         sql: str
 ) -> bool:
@@ -45,75 +48,6 @@ def is_restricted_sql(
         return True
     return False
 
-def magic_fqtn_handler(
-        possible_fqtn: str,
-        default_namespace: str
-    ) -> str:
-    """
-    Makes all of your wildest dreams come true... well not *that* one
-    """
-    input_db, input_schema, table = parse_fqtn(possible_fqtn, default_namespace, False)
-    default_database, default_schema = parse_namespace(default_namespace)
-    database = input_db or default_database
-    schema = input_schema or default_schema
-    return make_fqtn(database, schema, table)
-
-def make_fqtn(
-        database: str,
-        schema: str,
-        table: str
-) -> str:
-    """
-    Accepts component parts and returns a fully qualified table string
-    """
-    return f"{database}.{schema}.{table}"
-
-def make_namespace_from_fqtn(
-        fqtn: str
-) -> str:
-    """
-    Accepts component parts and returns a fully qualified namespace string
-    """
-    database, schema, _ = parse_fqtn(fqtn)
-    return f"{database}.{schema}"
-
-def parse_fqtn(
-        fqtn: str,
-        default_namespace: str = None,
-        strict: bool = True
-) -> tuple:
-    """
-    Accepts a possible fully qualified table string and returns its component parts
-    """
-    if strict:
-        fqtn = validate_fqtn(fqtn)
-        return (* fqtn.split("."),)
-    database, schema = parse_namespace(default_namespace)
-    if fqtn.count(".") == 2:
-        return (* fqtn.split("."),)
-    if fqtn.count(".") == 1:
-        return (database, * fqtn.split("."),)
-    if fqtn.count(".") == 0:
-        return (database, schema, fqtn)
-    raise ValueError(f'{fqtn} is not a well-formed fqtn')
-
-def parse_namespace(
-        namespace: str
-) -> tuple:
-    """
-    Accepts a possible namespace string and returns its component parts
-    """
-    namespace = validate_namespace(namespace)
-    return tuple(namespace.split("."))
-
-def parse_table_and_schema_from_fqtn(
-    fqtn: str
-) -> tuple:
-    """
-    Accepts a possible FQTN and returns the schema and table from it
-    """
-    fqtn = validate_fqtn(fqtn)
-    return tuple(fqtn.split(".")[1:])
 
 def random_table_name() -> str:
     """
@@ -121,25 +55,6 @@ def random_table_name() -> str:
     """
     return 'RQL_'+''.join(random.choice(string.ascii_uppercase) for x in range(10))
 
-def validate_fqtn(
-        fqtn: str
-    ) -> str:
-    """
-    Accepts a possible fully qualified table string and decides whether it is well formed
-    """
-    if re.match(r'^[^\s]+\.[^\s]+\.[^\s]+', fqtn):
-        return fqtn
-    raise ValueError(f'{fqtn} is not a well-formed fqtn')
-
-def validate_namespace(
-        namespace: str
-    ) -> bool:
-    """
-    Accepts a possible namespace string and decides whether it is well formed
-    """
-    if re.match(r'^[^\s]+\.[^\s]+', namespace):
-        return namespace
-    raise ValueError(f'{namespace} is not a well-formed namespace')
 
 def wrap_table(
         parent_table: str

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.2.0'
+__version__ = '1.3.0'

--- a/rasgoql/requirements-dev.txt
+++ b/rasgoql/requirements-dev.txt
@@ -5,7 +5,7 @@ pandas
 pre-commit
 python-dotenv
 pyyaml
-rasgotransforms~=1.1
+rasgotransforms~=1.2
 requests
 snowflake-connector-python
 snowflake-connector-python[pandas]

--- a/rasgoql/requirements-mysql.txt
+++ b/rasgoql/requirements-mysql.txt
@@ -1,2 +1,2 @@
 SQLAlchemy
-psycopg2
+pymysql

--- a/rasgoql/requirements.txt
+++ b/rasgoql/requirements.txt
@@ -2,5 +2,5 @@ jinja2
 pandas
 python-dotenv
 pyyaml
-rasgotransforms~=1.1
+rasgotransforms~=1.2
 requests

--- a/rasgoql/setup.py
+++ b/rasgoql/setup.py
@@ -28,6 +28,10 @@ with open(os.path.join(_here, 'requirements-postgres.txt'), encoding='utf-8') as
     req_lines = f.read()
     postgres_requirements = req_lines.splitlines()
 
+with open(os.path.join(_here, 'requirements-mysql.txt'), encoding='utf-8') as f:
+    req_lines = f.read()
+    mysql_requirements = req_lines.splitlines() 
+
 setup(
     name='rasgoql',
     version=__version__,
@@ -52,7 +56,8 @@ setup(
     extras_require={
         "snowflake":  sf_requirements,
         "bigquery": bq_requirements,
-        "postgres": postgres_requirements
+        "postgres": postgres_requirements,
+        "mysql": mysql_requirements
     },
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Closes #46 

A few changes to note here:
1. I pulled a lot of SQLAlchemy abstraction up to a base class that Postgres and MySQL both now inherit from
2. MySQL revealed a refactor we should do in our handling of FQTNs and Namespaces. Since each DW (specifically, PG and MySQL) can have different formations of FQTN (e.g., MySQL expects just a database.table_name), we should make the methods that validate FQTNs and namespaces implementable by each DW class.