### PR TITLE
Remove transform_type from Template class

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Add
 - Add SQLChain to/from YAML workflow
+- Add support for Redshift
 
 ### Change
 - N/A
@@ -65,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for MySQL
 
+## [1.3.1] - 2022-04-04
+### Added
+- Added `tags` property to `TransformTemplate` class
+### Removed
+- Removed `transform_type` property from `TransformTemplate` class
+
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/
@@ -73,3 +80,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.1]: https://pypi.org/project/rasgoql/1.1.1/
 [1.2.0]: https://pypi.org/project/rasgoql/1.2.0/
 [1.3.0]: https://pypi.org/project/rasgoql/1.3.0/
+[1.3.1]: https://pypi.org/project/rasgoql/1.3.1/

--- a/rasgoql/rasgoql/primitives/transforms.py
+++ b/rasgoql/rasgoql/primitives/transforms.py
@@ -188,14 +188,14 @@ class TransformTemplate:
             name: str,
             arguments: List[dict],
             source_code: str,
-            transform_type: str,
-            description: str = None
+            description: str = None,
+            tags: List[str] = None
         ):
         self.name = name
         self.arguments = arguments
         self.source_code = source_code
-        self.transform_type = transform_type
         self.description = description
+        self.tags = tags
 
     def __repr__(self) -> str:
         arg_str = ', '.join(f'{arg.get("name")}: {arg.get("type")}' for arg in self.arguments)
@@ -205,7 +205,7 @@ class TransformTemplate:
         """
         Return a pretty string definition of this Transform
         """
-        pretty_string = f'''{self.transform_type.title()} Transform: {self.name}
+        pretty_string = f'''Transform: {self.name}
         Description: {self.description}
         Arguments: {self.arguments}
         SourceCode: {self.source_code}

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/rasgoql/requirements-dev.txt
+++ b/rasgoql/requirements-dev.txt
@@ -5,7 +5,7 @@ pandas
 pre-commit
 python-dotenv
 pyyaml
-rasgotransforms~=1.2
+rasgotransforms~=1.3
 requests
 snowflake-connector-python
 snowflake-connector-python[pandas]

--- a/rasgoql/requirements.txt
+++ b/rasgoql/requirements.txt
@@ -2,5 +2,5 @@ jinja2
 pandas
 python-dotenv
 pyyaml
-rasgotransforms~=1.2
+rasgotransforms~=1.3
 requests


### PR DESCRIPTION
This PR removes the outdated `transform_type` property from a `TransformTemplate` class

It is a companion to PR: https://github.com/rasgointelligence/RasgoTransforms/pull/148