### PR TITLE
Add missing setup extras for redshift

### DIFF
--- a/rasgoql/rasgoql/main.py
+++ b/rasgoql/rasgoql/main.py
@@ -95,8 +95,8 @@ class RasgoQL:
                 udt = t
         if udt:
             return udt.define()
-        raise ValueError(f'{name} is not a valid Tranform name. ' \
-                           'Run `.list_transforms()` to see available transforms.')
+        raise ValueError(f'{name} is not a valid Tranform name. '
+                         'Run `.list_transforms()` to see available transforms.')
 
     def query(
             self,

--- a/rasgoql/rasgoql/utils/sql.py
+++ b/rasgoql/rasgoql/utils/sql.py
@@ -68,7 +68,7 @@ def random_table_name() -> str:
 
 def validate_namespace(
     namespace: str
-) -> bool:
+) -> str:
     """
     Accepts a possible namespace string and decides whether it is well-formed
     """
@@ -79,7 +79,7 @@ def validate_namespace(
 
 def wrap_table(
         parent_table: str
-    )-> str:
+) -> str:
     """
     Calculates a unique table string
     """

--- a/rasgoql/setup.py
+++ b/rasgoql/setup.py
@@ -32,6 +32,10 @@ with open(os.path.join(_here, 'requirements-mysql.txt'), encoding='utf-8') as f:
     req_lines = f.read()
     mysql_requirements = req_lines.splitlines()
 
+with open(os.path.join(_here, 'requirements-redshift.txt'), encoding='utf-8') as f:
+    req_lines = f.read()
+    redshift_requirements = req_lines.splitlines()
+
 setup(
     name='rasgoql',
     version=__version__,
@@ -57,11 +61,12 @@ setup(
         "snowflake":  sf_requirements,
         "bigquery": bq_requirements,
         "postgres": postgres_requirements,
-        "mysql": mysql_requirements
+        "mysql": mysql_requirements,
+        "redshift": redshift_requirements,
     },
     include_package_data=True,
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The `extras_require` was missing for redshift. Then some other small styling cleanup. 

Only other real change is the classifier from pre-alpha to at least stage 3, alpha. I don't know if we want to call it full on 5 mature yet, but I think 3 or 4 should be used instead of 2. 