### PR TITLE
Add Missing Req

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -89,6 +89,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing get_object_details for postgres
 
+## [1.5.3] - 2022-05-20
+### Added
+- Added `get_columns` to list of source functions
+
+## [1.5.4] - 2022-05-23
+### Added
+- Added db-dtypes as a dependency to optional rasgoql[bigquery] package to prevent breaking changes in google-cloud-bigquery v3.0.0
+
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/
@@ -102,3 +110,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.5.0]: https://pypi.org/project/rasgoql/1.5.0/
 [1.5.1]: https://pypi.org/project/rasgoql/1.5.1/
 [1.5.2]: https://pypi.org/project/rasgoql/1.5.2/
+[1.5.3]: https://pypi.org/project/rasgoql/1.5.3/
+[1.5.4]: https://pypi.org/project/rasgoql/1.5.4/

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.5.3'
+__version__ = '1.5.4'

--- a/rasgoql/requirements-bigquery.txt
+++ b/rasgoql/requirements-bigquery.txt
@@ -1,2 +1,4 @@
+# Needed until Google fixes breaking changes of v3.0.0
+db-dtypes
 google-auth-oauthlib
 google-cloud-bigquery

--- a/rasgoql/setup.py
+++ b/rasgoql/setup.py
@@ -48,6 +48,7 @@ setup(
         'Documentation': 'https://docs.rasgoql.com',
         'Source': 'https://github.com/rasgointelligence/RasgoQL',
         'Rasgo': 'https://www.rasgoml.com/',
+        'Changelog': 'https://github.com/rasgointelligence/RasgoQL/blob/main/rasgoql/CHANGELOG.md',
     },
     license='GNU Affero General Public License v3 or later (AGPLv3+)',
     packages=[


### PR DESCRIPTION
Add db-types requirement to our package so customers don't get errors when running on google-cloud-bigquery v3.0.0. Remove when Google fixes breaking changes of this version.