### PR TITLE
Get schema from queries without creating views

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -101,6 +101,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a bug where get_columns would not render for all DW types
 
+## [1.5.6] - 2022-06-20
+### Changed
+- Changed the `get_schema` method on Snowflake and BigQuery DW classes to get output columns without creating views
+
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/
@@ -117,3 +121,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.5.3]: https://pypi.org/project/rasgoql/1.5.3/
 [1.5.4]: https://pypi.org/project/rasgoql/1.5.4/
 [1.5.5]: https://pypi.org/project/rasgoql/1.5.5/
+[1.5.6]: https://pypi.org/project/rasgoql/1.5.6/

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.5.5'
+__version__ = '1.5.6'


### PR DESCRIPTION
A SQLChain with multiple transforms often needs to pass the schema (list of column names & data types) of one transform into another. When transforms are rendered as CTEs, the schemas do not yet exist. To solve this, rasgoQL creates and drops a view quickly to grab the schema that resulted from the operation.

Both Snowflake and BigQuery offer newer functionality that allows us to discontinue this behavior.

Snowflake offers the `cursor().describe()` method in it's [python package](https://docs.snowflake.com/en/user-guide/python-connector-example.html#retrieving-column-metadata).
BigQuery offers dry run, and we'll hack into the query_job's internal `statistics` property to get the rest b/c Google literally never makes anything easy.

This PR swaps out the `get_schema` methods to use the new approaches on the Snowflake and Biguery classes.