### PR TITLE
Overwrite on create

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -110,6 +110,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the `get_schema` method on all DW classes to accept a single `fqtn_or_sql` variable
 - Changed the behavior of transform arguments: when a Dataset or SQLChain class is passed in as an argument to a transform, it is automatically flattened to its corresponding fqtn or CTE then consumed in the transform.
 
+## [1.6.1] - 2022-06-27
+### Fixed
+- Fixed a bug in the `get_schema` method of SQLAlchemy DW classes where users were being asked to enter an `overwrite` param they cannot access
+
 
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/
@@ -128,3 +132,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.5.5]: https://pypi.org/project/rasgoql/1.5.5/
 [1.5.6]: https://pypi.org/project/rasgoql/1.5.6/
 [1.6.0]: https://pypi.org/project/rasgoql/1.6.0/
+[1.6.1]: https://pypi.org/project/rasgoql/1.6.1/

--- a/rasgoql/rasgoql/data/sqlalchemy.py
+++ b/rasgoql/rasgoql/data/sqlalchemy.py
@@ -246,7 +246,7 @@ class SQLAlchemyDataWarehouse(DataWarehouse):
         )
         # Check for SQL
         if self._is_select_statement(fqtn_or_sql):
-            self.create(fqtn_or_sql, "temp_schema", table_type="view")
+            self.create(fqtn_or_sql, "temp_schema", table_type="view", overwrite=True)
             query_response = self.execute_query(
                 query_sql.format(database=self.default_database, schema=self.default_schema, table="temp_schema"),
                 response="dict",

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.6.0'
+__version__ = '1.6.1'


### PR DESCRIPTION
This should fix a bug where postgres users are being told to pass in an overwrite parameter that they cannot access