### PR TITLE
Overwrite existing models in schema.yml file

### DIFF
--- a/rasgoql/CHANGELOG.md
+++ b/rasgoql/CHANGELOG.md
@@ -118,6 +118,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a postgres bug
 
+## [1.6.3] - 2022-06-27
+### Added
+- Added a jinja date macro
+
+## [1.6.4] - 2022-07-05
+### Changed
+- Changed default behavior of to_dbt function. Instead of always appending model details to the schema.yml file (which creates duplicate entries for existing models), rql will now check if a model entry already exists in the file and overwrite it. If the model does not exist, it will be appended.
+
+
 [1.0.0]: https://pypi.org/project/rasgoql/1.0.0/
 [1.0.1]: https://pypi.org/project/rasgoql/1.0.1/
 [1.0.2]: https://pypi.org/project/rasgoql/1.0.2/
@@ -137,3 +146,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.6.0]: https://pypi.org/project/rasgoql/1.6.0/
 [1.6.1]: https://pypi.org/project/rasgoql/1.6.1/
 [1.6.2]: https://pypi.org/project/rasgoql/1.6.2/
+[1.6.3]: https://pypi.org/project/rasgoql/1.6.3/
+[1.6.4]: https://pypi.org/project/rasgoql/1.6.4/

--- a/rasgoql/rasgoql/utils/dbt.py
+++ b/rasgoql/rasgoql/utils/dbt.py
@@ -141,14 +141,13 @@ def save_schema_file(
     schema_definition = existing_schema or {"version": 2, "models": []}
 
     columns_list = [{"name:": row[0]} for row in schema]
-    model_found = False
-    for m in schema_definition["models"]:
-        if m.get("name") == model_name:
-            m["columns"] = columns_list
+    for mod in schema_definition["models"]:
+        if mod.get("name") == model_name:
+            mod["columns"] = columns_list
             if config_args:
-                m["config"] = config_args
-            model_found = True
-    if not model_found:
+                mod["config"] = config_args
+            break
+    else:
         model_dict = {"name": model_name, "columns": columns_list}
         if config_args:
             model_dict.update({"config": config_args})

--- a/rasgoql/rasgoql/version.py
+++ b/rasgoql/rasgoql/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.6.3'
+__version__ = '1.6.4'


### PR DESCRIPTION
The default behavior of rasgoQL is to always append model information to the schema.yml file. If a model already exists in a file, rasgoQL appends a duplicate entry.

Behavior Change: This PR instructs rasgoQL to check if a model already exists in the schema.yml file and overwrite it if it does. If the model does not exist, it will be appended.